### PR TITLE
fix: always update Polymarket cached prices to prevent staleness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,38 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "arb-bot"
-version = "2.0.0"
-dependencies = [
- "anyhow",
- "arrayvec",
- "base64 0.22.1",
- "chrono",
- "criterion",
- "dotenvy",
- "ethers",
- "futures-util",
- "governor",
- "hex",
- "hmac",
- "nonzero_ext",
- "pkcs1",
- "rand 0.8.5",
- "reqwest",
- "rsa",
- "rustc-hash",
- "serde",
- "serde_json",
- "sha2",
- "tiny-keccak",
- "tokio",
- "tokio-tungstenite 0.21.0",
- "tracing",
- "tracing-subscriber",
- "wide",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2618,38 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prediction-market-arbitrage"
+version = "2.0.0"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "base64 0.22.1",
+ "chrono",
+ "criterion",
+ "dotenvy",
+ "ethers",
+ "futures-util",
+ "governor",
+ "hex",
+ "hmac",
+ "nonzero_ext",
+ "pkcs1",
+ "rand 0.8.5",
+ "reqwest",
+ "rsa",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tiny-keccak",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "tracing",
+ "tracing-subscriber",
+ "wide",
+]
 
 [[package]]
 name = "prettyplease"


### PR DESCRIPTION
The price change handler was only updating cached prices when the new price was better (lower). This caused the cache to become optimistically stale - it would show the best prices that ever existed rather than current prices.

Now the cache always reflects current market state, while arb detection still only triggers when prices improve (since worse prices can't create new opportunities).

Also includes heartbeat display improvements from main.rs.