### PR TITLE
feat(remote): enforce one-trader-one-platform with leg-based execution

### DIFF
--- a/controller/src/remote_execution.rs
+++ b/controller/src/remote_execution.rs
@@ -7,15 +7,16 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use crate::circuit_breaker::CircuitBreaker;
-use crate::remote_protocol::{ArbType as WsArbType, IncomingMessage, Platform as WsPlatform};
-use crate::remote_trader::RemoteTraderHandle;
-use crate::types::{ArbType, FastExecutionRequest, GlobalState};
+use crate::remote_protocol::{IncomingMessage, OrderAction, OutcomeSide, Platform as WsPlatform};
+use crate::remote_trader::RemoteTraderRouter;
+use crate::types::{ArbType, FastExecutionRequest, GlobalState, MarketPair};
 
 pub struct RemoteExecutor {
     state: Arc<GlobalState>,
     circuit_breaker: Arc<CircuitBreaker>,
-    trader: RemoteTraderHandle,
+    trader: RemoteTraderRouter,
     in_flight: Arc<[AtomicU64; 8]>,
+    leg_seq: AtomicU64,
     pub dry_run: bool,
 }
 
@@ -23,7 +24,7 @@ impl RemoteExecutor {
     pub fn new(
         state: Arc<GlobalState>,
         circuit_breaker: Arc<CircuitBreaker>,
-        trader: RemoteTraderHandle,
+        trader: RemoteTraderRouter,
         dry_run: bool,
     ) -> Self {
         Self {
@@ -31,6 +32,7 @@ impl RemoteExecutor {
             circuit_breaker,
             trader,
             in_flight: Arc::new(std::array::from_fn(|_| AtomicU64::new(0))),
+            leg_seq: AtomicU64::new(1),
             dry_run,
         }
     }
@@ -103,22 +105,30 @@ impl RemoteExecutor {
             );
         }
 
-        let msg = IncomingMessage::Execute {
-            market_id,
-            arb_type: to_ws_arb(req.arb_type),
-            yes_price: req.yes_price,
-            no_price: req.no_price,
-            yes_size: req.yes_size,
-            no_size: req.no_size,
-            pair_id: Some(pair.pair_id.to_string()),
-            description: Some(pair.description.to_string()),
-            kalshi_market_ticker: Some(pair.kalshi_market_ticker.to_string()),
-            poly_yes_token: Some(pair.poly_yes_token.to_string()),
-            poly_no_token: Some(pair.poly_no_token.to_string()),
-        };
+        // Build legs for this arb, then only dispatch if required remote traders are available.
+        let legs = build_legs(&req, &pair, max_contracts, &self.leg_seq);
+        if legs.is_empty() {
+            self.release_in_flight_delayed(market_id);
+            return Ok(());
+        }
 
-        if !self.trader.try_send(msg) {
-            warn!("[REMOTE_EXEC] No trader connected; dropping execute");
+        // Enforce availability: cross-platform arbs require both remote traders.
+        if !can_dispatch(&self.trader, req.arb_type).await {
+            warn!(
+                "[REMOTE_EXEC] Missing remote trader(s) for {:?}; dropping arb market_id={}",
+                req.arb_type, market_id
+            );
+            self.release_in_flight_delayed(market_id);
+            return Ok(());
+        }
+
+        for (platform, msg) in legs {
+            if !self.trader.try_send(platform, msg).await {
+                warn!(
+                    "[REMOTE_EXEC] Failed to send leg to {:?}; trader not connected? market_id={}",
+                    platform, market_id
+                );
+            }
         }
 
         self.release_in_flight_delayed(market_id);
@@ -126,24 +136,175 @@ impl RemoteExecutor {
     }
 }
 
-fn to_ws_arb(a: ArbType) -> WsArbType {
-    match a {
-        ArbType::PolyYesKalshiNo => WsArbType::PolyYesKalshiNo,
-        ArbType::KalshiYesPolyNo => WsArbType::KalshiYesPolyNo,
-        ArbType::PolyOnly => WsArbType::PolyOnly,
-        ArbType::KalshiOnly => WsArbType::KalshiOnly,
+async fn can_dispatch(router: &RemoteTraderRouter, arb_type: ArbType) -> bool {
+    match arb_type {
+        ArbType::PolyYesKalshiNo | ArbType::KalshiYesPolyNo => {
+            router.is_connected(WsPlatform::Kalshi).await && router.is_connected(WsPlatform::Polymarket).await
+        }
+        ArbType::PolyOnly => router.is_connected(WsPlatform::Polymarket).await,
+        ArbType::KalshiOnly => router.is_connected(WsPlatform::Kalshi).await,
     }
 }
 
-#[allow(dead_code)]
-fn to_ws_platforms(platforms: &[crate::types::Platform]) -> Vec<WsPlatform> {
-    platforms
-        .iter()
-        .map(|p| match p {
-            crate::types::Platform::Kalshi => WsPlatform::Kalshi,
-            crate::types::Platform::Polymarket => WsPlatform::Polymarket,
-        })
-        .collect()
+fn build_legs(
+    req: &FastExecutionRequest,
+    pair: &MarketPair,
+    contracts: i64,
+    leg_seq: &AtomicU64,
+) -> Vec<(WsPlatform, IncomingMessage)> {
+    let mk_leg_id = |suffix: &str| -> String {
+        let n = leg_seq.fetch_add(1, Ordering::Relaxed);
+        format!("m{}-{}-{}", req.market_id, n, suffix)
+    };
+
+    let pair_id = Some(pair.pair_id.to_string());
+    let description = Some(pair.description.to_string());
+
+    match req.arb_type {
+        // Cross-platform: Poly YES + Kalshi NO
+        ArbType::PolyYesKalshiNo => vec![
+            (
+                WsPlatform::Polymarket,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("poly-yes"),
+                    platform: WsPlatform::Polymarket,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::Yes,
+                    price: req.yes_price,
+                    contracts,
+                    kalshi_market_ticker: None,
+                    poly_token: Some(pair.poly_yes_token.to_string()),
+                    pair_id: pair_id.clone(),
+                    description: description.clone(),
+                },
+            ),
+            (
+                WsPlatform::Kalshi,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("kalshi-no"),
+                    platform: WsPlatform::Kalshi,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::No,
+                    price: req.no_price,
+                    contracts,
+                    kalshi_market_ticker: Some(pair.kalshi_market_ticker.to_string()),
+                    poly_token: None,
+                    pair_id,
+                    description,
+                },
+            ),
+        ],
+
+        // Cross-platform: Kalshi YES + Poly NO
+        ArbType::KalshiYesPolyNo => vec![
+            (
+                WsPlatform::Kalshi,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("kalshi-yes"),
+                    platform: WsPlatform::Kalshi,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::Yes,
+                    price: req.yes_price,
+                    contracts,
+                    kalshi_market_ticker: Some(pair.kalshi_market_ticker.to_string()),
+                    poly_token: None,
+                    pair_id: pair_id.clone(),
+                    description: description.clone(),
+                },
+            ),
+            (
+                WsPlatform::Polymarket,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("poly-no"),
+                    platform: WsPlatform::Polymarket,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::No,
+                    price: req.no_price,
+                    contracts,
+                    kalshi_market_ticker: None,
+                    poly_token: Some(pair.poly_no_token.to_string()),
+                    pair_id,
+                    description,
+                },
+            ),
+        ],
+
+        // Same-platform: Poly YES + Poly NO (both legs to the polymarket trader)
+        ArbType::PolyOnly => vec![
+            (
+                WsPlatform::Polymarket,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("poly-yes"),
+                    platform: WsPlatform::Polymarket,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::Yes,
+                    price: req.yes_price,
+                    contracts,
+                    kalshi_market_ticker: None,
+                    poly_token: Some(pair.poly_yes_token.to_string()),
+                    pair_id: pair_id.clone(),
+                    description: description.clone(),
+                },
+            ),
+            (
+                WsPlatform::Polymarket,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("poly-no"),
+                    platform: WsPlatform::Polymarket,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::No,
+                    price: req.no_price,
+                    contracts,
+                    kalshi_market_ticker: None,
+                    poly_token: Some(pair.poly_no_token.to_string()),
+                    pair_id,
+                    description,
+                },
+            ),
+        ],
+
+        // Same-platform: Kalshi YES + Kalshi NO (both legs to the kalshi trader)
+        ArbType::KalshiOnly => vec![
+            (
+                WsPlatform::Kalshi,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("kalshi-yes"),
+                    platform: WsPlatform::Kalshi,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::Yes,
+                    price: req.yes_price,
+                    contracts,
+                    kalshi_market_ticker: Some(pair.kalshi_market_ticker.to_string()),
+                    poly_token: None,
+                    pair_id: pair_id.clone(),
+                    description: description.clone(),
+                },
+            ),
+            (
+                WsPlatform::Kalshi,
+                IncomingMessage::ExecuteLeg {
+                    market_id: req.market_id,
+                    leg_id: mk_leg_id("kalshi-no"),
+                    platform: WsPlatform::Kalshi,
+                    action: OrderAction::Buy,
+                    side: OutcomeSide::No,
+                    price: req.no_price,
+                    contracts,
+                    kalshi_market_ticker: Some(pair.kalshi_market_ticker.to_string()),
+                    poly_token: None,
+                    pair_id,
+                    description,
+                },
+            ),
+        ],
+    }
 }
 
 /// Remote execution event loop - forwards arbitrage opportunities to the remote trader.
@@ -163,6 +324,152 @@ pub async fn run_remote_execution_loop(
                 error!("[REMOTE_EXEC] error: {}", e);
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
+    use crate::remote_protocol::{IncomingMessage as WsMsg, Platform as WsPlatform};
+    use crate::remote_trader::RemoteTraderServer;
+    use std::net::SocketAddr;
+
+    fn make_test_pair() -> MarketPair {
+        MarketPair {
+            pair_id: "test-pair".into(),
+            league: "epl".into(),
+            market_type: crate::types::MarketType::Moneyline,
+            description: "Test Market".into(),
+            kalshi_event_ticker: "KXTEST".into(),
+            kalshi_market_ticker: "KXTEST-MKT".into(),
+            poly_slug: "test".into(),
+            poly_yes_token: "0x_yes".into(),
+            poly_no_token: "0x_no".into(),
+            line_value: None,
+            team_suffix: None,
+        }
+    }
+
+    fn cb_disabled() -> Arc<CircuitBreaker> {
+        Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
+            max_position_per_market: 1_000_000,
+            max_total_position: 1_000_000,
+            max_daily_loss: 1_000_000.0,
+            max_consecutive_errors: 999,
+            cooldown_secs: 0,
+            enabled: false,
+        }))
+    }
+
+    fn make_state_with_pair(pair: MarketPair) -> Arc<GlobalState> {
+        let state = Arc::new(GlobalState::new());
+        let id = state.add_pair(pair).expect("add_pair");
+        assert_eq!(id, 0);
+        state
+    }
+
+    #[tokio::test]
+    async fn cross_platform_requires_both_traders() {
+        let state = make_state_with_pair(make_test_pair());
+        let cb = cb_disabled();
+
+        let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = RemoteTraderServer::new(bind, vec![WsPlatform::Kalshi, WsPlatform::Polymarket], true);
+        let router = server.router();
+
+        let mut kalshi_rx = router.test_register(WsPlatform::Kalshi).await;
+        // No polymarket trader connected
+
+        let exec = RemoteExecutor::new(state, cb, router, true);
+        let req = FastExecutionRequest {
+            market_id: 0,
+            yes_price: 40,
+            no_price: 50,
+            yes_size: 1000,
+            no_size: 1000,
+            arb_type: ArbType::PolyYesKalshiNo,
+            detected_ns: 0,
+        };
+        exec.process(req).await.unwrap();
+
+        assert!(kalshi_rx.try_recv().is_err(), "should not send when missing other platform");
+    }
+
+    #[tokio::test]
+    async fn cross_platform_sends_one_leg_to_each_trader() {
+        let state = make_state_with_pair(make_test_pair());
+        let cb = cb_disabled();
+
+        let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = RemoteTraderServer::new(bind, vec![WsPlatform::Kalshi, WsPlatform::Polymarket], true);
+        let router = server.router();
+
+        let mut kalshi_rx = router.test_register(WsPlatform::Kalshi).await;
+        let mut poly_rx = router.test_register(WsPlatform::Polymarket).await;
+
+        let exec = RemoteExecutor::new(state, cb, router, true);
+        let req = FastExecutionRequest {
+            market_id: 0,
+            yes_price: 40,
+            no_price: 50,
+            yes_size: 1000,
+            no_size: 1000,
+            arb_type: ArbType::PolyYesKalshiNo,
+            detected_ns: 0,
+        };
+        exec.process(req).await.unwrap();
+
+        let kalshi_msg = kalshi_rx.try_recv().expect("kalshi leg");
+        let poly_msg = poly_rx.try_recv().expect("poly leg");
+
+        match kalshi_msg {
+            WsMsg::ExecuteLeg { platform, kalshi_market_ticker, poly_token, .. } => {
+                assert_eq!(platform, WsPlatform::Kalshi);
+                assert!(kalshi_market_ticker.is_some());
+                assert!(poly_token.is_none());
+            }
+            other => panic!("unexpected message to kalshi: {:?}", other),
+        }
+
+        match poly_msg {
+            WsMsg::ExecuteLeg { platform, kalshi_market_ticker, poly_token, .. } => {
+                assert_eq!(platform, WsPlatform::Polymarket);
+                assert!(kalshi_market_ticker.is_none());
+                assert!(poly_token.is_some());
+            }
+            other => panic!("unexpected message to poly: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn same_platform_can_send_two_legs_to_one_trader() {
+        let state = make_state_with_pair(make_test_pair());
+        let cb = cb_disabled();
+
+        let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = RemoteTraderServer::new(bind, vec![WsPlatform::Polymarket], true);
+        let router = server.router();
+
+        let mut poly_rx = router.test_register(WsPlatform::Polymarket).await;
+
+        let exec = RemoteExecutor::new(state, cb, router, true);
+        let req = FastExecutionRequest {
+            market_id: 0,
+            yes_price: 48,
+            no_price: 50,
+            yes_size: 1000,
+            no_size: 1000,
+            arb_type: ArbType::PolyOnly,
+            detected_ns: 0,
+        };
+        exec.process(req).await.unwrap();
+
+        let m1 = poly_rx.try_recv().expect("first poly leg");
+        let m2 = poly_rx.try_recv().expect("second poly leg");
+
+        assert!(matches!(m1, WsMsg::ExecuteLeg { platform: WsPlatform::Polymarket, .. }));
+        assert!(matches!(m2, WsMsg::ExecuteLeg { platform: WsPlatform::Polymarket, .. }));
     }
 }
 

--- a/controller/src/remote_trader.rs
+++ b/controller/src/remote_trader.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, RwLock};
 use tokio_tungstenite::{accept_async, tungstenite::Message};
@@ -15,34 +16,60 @@ use tracing::{info, warn};
 use crate::remote_protocol::{IncomingMessage, OutgoingMessage, Platform};
 
 #[derive(Clone)]
-pub struct RemoteTraderHandle {
-    outgoing: Arc<RwLock<Option<mpsc::UnboundedSender<IncomingMessage>>>>,
+pub struct RemoteTraderRouter {
+    outgoing: Arc<RwLock<std::collections::HashMap<Platform, TraderSlot>>>,
 }
 
-impl RemoteTraderHandle {
-    pub async fn is_connected(&self) -> bool {
-        self.outgoing.read().await.is_some()
+#[derive(Clone)]
+struct TraderSlot {
+    conn_id: u64,
+    tx: mpsc::UnboundedSender<IncomingMessage>,
+}
+
+impl RemoteTraderRouter {
+    pub async fn is_connected(&self, platform: Platform) -> bool {
+        self.outgoing.read().await.contains_key(&platform)
     }
 
     /// Send a message to the currently connected trader (if any).
-    pub fn try_send(&self, msg: IncomingMessage) -> bool {
-        if let Some(tx) = self.outgoing.blocking_read().as_ref() {
-            tx.send(msg).is_ok()
-        } else {
-            false
-        }
+    pub async fn try_send(&self, platform: Platform, msg: IncomingMessage) -> bool {
+        self.outgoing
+            .read()
+            .await
+            .get(&platform)
+            .map(|slot| slot.tx.send(msg).is_ok())
+            .unwrap_or(false)
     }
 
-    pub async fn send(&self, msg: IncomingMessage) -> Result<()> {
+    pub async fn send(&self, platform: Platform, msg: IncomingMessage) -> Result<()> {
         let tx = self
             .outgoing
             .read()
             .await
-            .as_ref()
-            .cloned()
-            .context("no trader connected")?;
-        tx.send(msg).map_err(|_| anyhow::anyhow!("trader channel closed"))?;
+            .get(&platform)
+            .map(|slot| slot.tx.clone())
+            .context("no trader connected for platform")?;
+        tx.send(msg)
+            .map_err(|_| anyhow::anyhow!("trader channel closed"))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+impl RemoteTraderRouter {
+    /// Test helper: register a fake connected trader for a platform and get a receiver
+    /// for messages sent by the controller.
+    pub async fn test_register(&self, platform: Platform) -> mpsc::UnboundedReceiver<IncomingMessage> {
+        let (tx, rx) = mpsc::unbounded_channel::<IncomingMessage>();
+        let mut map = self.outgoing.write().await;
+        map.insert(
+            platform,
+            TraderSlot {
+                conn_id: 0,
+                tx,
+            },
+        );
+        rx
     }
 }
 
@@ -50,7 +77,7 @@ pub struct RemoteTraderServer {
     bind: SocketAddr,
     platforms: Vec<Platform>,
     dry_run: bool,
-    handle: RemoteTraderHandle,
+    router: RemoteTraderRouter,
 }
 
 impl RemoteTraderServer {
@@ -59,14 +86,14 @@ impl RemoteTraderServer {
             bind,
             platforms,
             dry_run,
-            handle: RemoteTraderHandle {
-                outgoing: Arc::new(RwLock::new(None)),
+            router: RemoteTraderRouter {
+                outgoing: Arc::new(RwLock::new(std::collections::HashMap::new())),
             },
         }
     }
 
-    pub fn handle(&self) -> RemoteTraderHandle {
-        self.handle.clone()
+    pub fn router(&self) -> RemoteTraderRouter {
+        self.router.clone()
     }
 
     pub async fn run(self) -> Result<()> {
@@ -78,111 +105,181 @@ impl RemoteTraderServer {
             self.bind, self.dry_run
         );
 
+        let conn_counter = Arc::new(AtomicU64::new(1));
+
         loop {
             let (stream, peer) = listener.accept().await.context("accept trader tcp")?;
-            info!("[REMOTE] Trader connected from {}", peer);
+            let allowed_platforms = self.platforms.clone();
+            let dry_run = self.dry_run;
+            let router = self.router.clone();
+            let conn_id = conn_counter.fetch_add(1, Ordering::Relaxed);
 
-            let ws = accept_async(stream).await.context("accept trader websocket")?;
-            let (mut write, mut read) = ws.split();
+            tokio::spawn(async move {
+                info!("[REMOTE] Trader connected from {} (conn_id={})", peer, conn_id);
 
-            let (out_tx, mut out_rx) = mpsc::unbounded_channel::<IncomingMessage>();
-            {
-                let mut guard = self.handle.outgoing.write().await;
-                *guard = Some(out_tx.clone());
-            }
-
-            // Immediately init the trader.
-            let init = IncomingMessage::Init {
-                platforms: self.platforms.clone(),
-                dry_run: self.dry_run,
-            };
-            let _ = out_tx.send(init);
-
-            // Writer task
-            let writer = tokio::spawn(async move {
-                while let Some(msg) = out_rx.recv().await {
-                    match serde_json::to_string(&msg) {
-                        Ok(json) => {
-                            if let Err(e) = write.send(Message::Text(json)).await {
-                                return Err(anyhow::anyhow!("ws send failed: {}", e));
-                            }
-                        }
-                        Err(e) => warn!("[REMOTE] serialize error: {}", e),
+                let ws = match accept_async(stream).await {
+                    Ok(ws) => ws,
+                    Err(e) => {
+                        warn!("[REMOTE] accept trader websocket failed: {}", e);
+                        return;
                     }
-                }
-                Ok::<(), anyhow::Error>(())
-            });
+                };
+                let (mut write, mut read) = ws.split();
 
-            // Reader task
-            let out_tx_for_pong = out_tx.clone();
-            let reader = tokio::spawn(async move {
-                while let Some(frame) = read.next().await {
-                    match frame {
-                        Ok(Message::Text(text)) => match serde_json::from_str::<OutgoingMessage>(&text)
-                        {
-                            Ok(OutgoingMessage::Ping { timestamp }) => {
-                                // Trader heartbeat ping → respond with pong so trader stays healthy.
-                                let _ = out_tx_for_pong.send(IncomingMessage::Pong { timestamp });
-                            }
-                            Ok(OutgoingMessage::InitAck { success, error, .. }) => {
-                                if success {
-                                    info!("[REMOTE] Trader init_ack: success");
-                                } else {
-                                    warn!(
-                                        "[REMOTE] Trader init_ack: failure: {}",
-                                        error.unwrap_or_else(|| "unknown".to_string())
-                                    );
+                let (out_tx, mut out_rx) = mpsc::unbounded_channel::<IncomingMessage>();
+
+                // Immediately init the trader (it should respond with init_ack including its platform).
+                let _ = out_tx.send(IncomingMessage::Init {
+                    platforms: allowed_platforms.clone(),
+                    dry_run,
+                });
+
+                // Writer task
+                let writer = tokio::spawn(async move {
+                    while let Some(msg) = out_rx.recv().await {
+                        match serde_json::to_string(&msg) {
+                            Ok(json) => {
+                                if let Err(e) = write.send(Message::Text(json)).await {
+                                    return Err(anyhow::anyhow!("ws send failed: {}", e));
                                 }
                             }
-                            Ok(OutgoingMessage::ExecutionResult {
-                                market_id,
-                                success,
-                                profit_cents,
-                                latency_ns,
-                                error,
-                            }) => {
-                                if success {
-                                    info!(
-                                        "[REMOTE] ✅ trader execution_result market_id={} profit={}¢ latency={}µs",
-                                        market_id,
-                                        profit_cents,
-                                        latency_ns / 1000
-                                    );
-                                } else {
-                                    warn!(
-                                        "[REMOTE] ❌ trader execution_result market_id={} err={}",
-                                        market_id,
-                                        error.unwrap_or_else(|| "unknown".to_string())
-                                    );
-                                }
-                            }
-                            Ok(other) => {
-                                info!("[REMOTE] trader msg: {:?}", other);
-                            }
-                            Err(e) => warn!("[REMOTE] parse error: {} (text={})", e, text),
-                        },
-                        Ok(Message::Close(_)) => break,
-                        Ok(_) => {}
-                        Err(e) => {
-                            return Err(anyhow::anyhow!("ws read failed: {}", e));
+                            Err(e) => warn!("[REMOTE] serialize error: {}", e),
                         }
                     }
-                }
-                Ok::<(), anyhow::Error>(())
+                    Ok::<(), anyhow::Error>(())
+                });
+
+                // Reader task: registers this connection to a platform after init_ack.
+                let out_tx_for_pong = out_tx.clone();
+                let router_for_register = router.clone();
+                let mut registered_platform: Option<Platform> = None;
+
+                let reader = tokio::spawn(async move {
+                    while let Some(frame) = read.next().await {
+                        match frame {
+                            Ok(Message::Text(text)) => match serde_json::from_str::<OutgoingMessage>(&text) {
+                                Ok(OutgoingMessage::Ping { timestamp }) => {
+                                    // Trader heartbeat ping → respond with pong so trader stays healthy.
+                                    let _ = out_tx_for_pong.send(IncomingMessage::Pong { timestamp });
+                                }
+                                Ok(OutgoingMessage::InitAck { success, platforms: reported_platforms, error }) => {
+                                    if !success {
+                                        warn!(
+                                            "[REMOTE] Trader init_ack failure (conn_id={}): {}",
+                                            conn_id,
+                                            error.unwrap_or_else(|| "unknown".to_string())
+                                        );
+                                        continue;
+                                    }
+
+                                    let Some(platform) = reported_platforms.first().copied() else {
+                                        warn!("[REMOTE] Trader init_ack missing platform (conn_id={})", conn_id);
+                                        continue;
+                                    };
+
+                                    // Validate platform is allowed by controller config.
+                                    if !platforms_allowed(&allowed_platforms, platform) {
+                                        warn!(
+                                            "[REMOTE] Trader reported unsupported platform {:?} (conn_id={})",
+                                            platform, conn_id
+                                        );
+                                        continue;
+                                    }
+
+                                    {
+                                        let mut map = router_for_register.outgoing.write().await;
+                                        if let Some(prev) = map.insert(
+                                            platform,
+                                            TraderSlot {
+                                                conn_id,
+                                                tx: out_tx_for_pong.clone(),
+                                            },
+                                        ) {
+                                            warn!(
+                                                "[REMOTE] Replacing trader for {:?}: prev_conn_id={} new_conn_id={}",
+                                                platform, prev.conn_id, conn_id
+                                            );
+                                        } else {
+                                            info!("[REMOTE] Registered trader for {:?} (conn_id={})", platform, conn_id);
+                                        }
+                                    }
+                                    registered_platform = Some(platform);
+                                }
+                                Ok(OutgoingMessage::LegResult { market_id, leg_id, platform, success, latency_ns, error }) => {
+                                    if success {
+                                        info!(
+                                            "[REMOTE] ✅ trader leg_result platform={:?} market_id={} leg_id={} latency={}µs",
+                                            platform,
+                                            market_id,
+                                            leg_id,
+                                            latency_ns / 1000
+                                        );
+                                    } else {
+                                        warn!(
+                                            "[REMOTE] ❌ trader leg_result platform={:?} market_id={} leg_id={} err={}",
+                                            platform,
+                                            market_id,
+                                            leg_id,
+                                            error.unwrap_or_else(|| "unknown".to_string())
+                                        );
+                                    }
+                                }
+                                Ok(OutgoingMessage::ExecutionResult { market_id, success, profit_cents, latency_ns, error }) => {
+                                    // Legacy support: keep logging old execute results.
+                                    if success {
+                                        info!(
+                                            "[REMOTE] ✅ trader execution_result market_id={} profit={}¢ latency={}µs",
+                                            market_id,
+                                            profit_cents,
+                                            latency_ns / 1000
+                                        );
+                                    } else {
+                                        warn!(
+                                            "[REMOTE] ❌ trader execution_result market_id={} err={}",
+                                            market_id,
+                                            error.unwrap_or_else(|| "unknown".to_string())
+                                        );
+                                    }
+                                }
+                                Ok(other) => {
+                                    info!("[REMOTE] trader msg: {:?}", other);
+                                }
+                                Err(e) => warn!("[REMOTE] parse error: {} (text={})", e, text),
+                            },
+                            Ok(Message::Close(_)) => break,
+                            Ok(_) => {}
+                            Err(e) => {
+                                return Err(anyhow::anyhow!("ws read failed: {}", e));
+                            }
+                        }
+                    }
+
+                    // Unregister on disconnect (if we were registered)
+                    if let Some(p) = registered_platform {
+                        let mut map = router_for_register.outgoing.write().await;
+                        if let Some(slot) = map.get(&p) {
+                            if slot.conn_id == conn_id {
+                                map.remove(&p);
+                                warn!("[REMOTE] Trader disconnected: {:?} (conn_id={})", p, conn_id);
+                            }
+                        }
+                    } else {
+                        warn!("[REMOTE] Trader disconnected before init_ack (conn_id={})", conn_id);
+                    }
+
+                    Ok::<(), anyhow::Error>(())
+                });
+
+                let _ = tokio::select! {
+                    r = reader => r,
+                    w = writer => w,
+                };
             });
-
-            // Wait until either side ends, then clear connection state.
-            let _ = tokio::select! {
-                r = reader => r,
-                w = writer => w,
-            };
-
-            {
-                let mut guard = self.handle.outgoing.write().await;
-                *guard = None;
-            }
-            warn!("[REMOTE] Trader disconnected; waiting for reconnect...");
         }
     }
+}
+
+fn platforms_allowed(allowed: &[Platform], platform: Platform) -> bool {
+    allowed.iter().any(|p| *p == platform)
 }
 

--- a/trader/src/api/polymarket.rs
+++ b/trader/src/api/polymarket.rs
@@ -74,6 +74,7 @@ impl PolymarketAsyncClient {
     }
 
     /// Derive API key from wallet (simplified - in production this would use the actual API)
+    #[allow(dead_code)]
     pub async fn derive_api_key(&self, _nonce: u64) -> Result<(String, String)> {
         // In a real implementation, this would call Polymarket's API key derivation endpoint
         // For now, we'll use a placeholder that requires the API key to be provided

--- a/trader/src/lib.rs
+++ b/trader/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub mod api;
 pub mod config;
-pub mod execution;
 pub mod heartbeat;
 pub mod paths;
 pub mod protocol;

--- a/trader/src/main.rs
+++ b/trader/src/main.rs
@@ -2,7 +2,6 @@
 
 mod api;
 mod config;
-mod execution;
 mod heartbeat;
 mod paths;
 mod protocol;

--- a/trader/src/trader.rs
+++ b/trader/src/trader.rs
@@ -5,15 +5,21 @@ use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
 use crate::config::Config;
-use crate::execution::{create_engines, ExecutionEngine, OrderRequest};
-use crate::protocol::{ArbType, IncomingMessage, OutgoingMessage, Platform};
+use crate::protocol::{ArbType, IncomingMessage, OrderAction, OutcomeSide, OutgoingMessage, Platform};
+
+use crate::api::kalshi::{KalshiApiClient, KalshiConfig};
+use crate::api::polymarket::{PolymarketAsyncClient, PreparedCreds, SharedAsyncClient};
+
+const POLY_CLOB_HOST: &str = "https://clob.polymarket.com";
+const POLYGON_CHAIN_ID: u64 = 137;
 
 /// Trader state
 pub enum TraderState {
     Uninitialized,
     Initialized {
-        platforms: Vec<Platform>,
-        engines: Vec<Box<dyn ExecutionEngine>>,
+        platform: Platform,
+        kalshi: Option<Arc<KalshiApiClient>>,
+        poly: Option<Arc<SharedAsyncClient>>,
         dry_run: bool,
     },
     Error {
@@ -25,7 +31,6 @@ pub enum TraderState {
 pub struct Trader {
     state: TraderState,
     config: Arc<Config>,
-    start_time: Instant,
 }
 
 impl Trader {
@@ -34,7 +39,6 @@ impl Trader {
         Self {
             state: TraderState::Uninitialized,
             config,
-            start_time: Instant::now(),
         }
     }
 
@@ -43,6 +47,34 @@ impl Trader {
         match msg {
             IncomingMessage::Init { platforms, dry_run } => {
                 self.handle_init(platforms, dry_run).await
+            }
+            IncomingMessage::ExecuteLeg {
+                market_id,
+                leg_id,
+                platform,
+                action,
+                side,
+                price,
+                contracts,
+                kalshi_market_ticker,
+                poly_token,
+                pair_id,
+                description,
+            } => {
+                self.handle_execute_leg(
+                    market_id,
+                    leg_id,
+                    platform,
+                    action,
+                    side,
+                    price,
+                    contracts,
+                    kalshi_market_ticker,
+                    poly_token,
+                    pair_id,
+                    description,
+                )
+                .await
             }
             IncomingMessage::Execute {
                 market_id,
@@ -84,32 +116,103 @@ impl Trader {
         platforms: Vec<Platform>,
         dry_run: bool,
     ) -> OutgoingMessage {
-        info!("[TRADER] Received init request: platforms={:?}, dry_run={}", platforms, dry_run);
+        info!(
+            "[TRADER] Received init request: platforms={:?}, dry_run={} (trader_platform={:?})",
+            platforms, dry_run, self.config.platform
+        );
 
-        // In dry-run mode, do not require credentials. Use local dry-run engines.
+        // The trader must only ever execute for its configured platform.
+        let platform = self.config.platform;
+        if !platforms.iter().any(|p| *p == platform) {
+            let msg = format!(
+                "Controller did not request our platform {:?} (requested={:?})",
+                platform, platforms
+            );
+            warn!("[TRADER] {}", msg);
+            self.state = TraderState::Error { message: msg.clone() };
+            return OutgoingMessage::InitAck {
+                success: false,
+                platforms: vec![],
+                error: Some(msg),
+            };
+        }
+
         let effective_dry_run = dry_run || self.config.dry_run;
 
-        let engines_result = if effective_dry_run {
-            Ok(platforms
-                .iter()
-                .map(|p| Box::new(crate::execution::dry_run::DryRunEngine::new(*p)) as Box<dyn ExecutionEngine>)
-                .collect())
-        } else {
-            create_engines(&platforms, &self.config).await
-        };
+        let init_res =
+            (|| -> anyhow::Result<(Option<Arc<KalshiApiClient>>, Option<Arc<SharedAsyncClient>>)> {
+                match platform {
+                    Platform::Kalshi => {
+                        if effective_dry_run {
+                            return Ok((None, None));
+                        }
+                        let api_key = self
+                            .config
+                            .kalshi_api_key
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("Missing KALSHI_API_KEY"))?;
+                        let private_key = self
+                            .config
+                            .kalshi_private_key
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("Missing KALSHI_PRIVATE_KEY"))?;
+                        let kalshi_cfg = KalshiConfig::new(api_key, &private_key)?;
+                        let kalshi = Arc::new(KalshiApiClient::new(kalshi_cfg));
+                        Ok((Some(kalshi), None))
+                    }
+                    Platform::Polymarket => {
+                        if effective_dry_run {
+                            return Ok((None, None));
+                        }
+                        let private_key = self
+                            .config
+                            .polymarket_private_key
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("Missing POLYMARKET_PRIVATE_KEY"))?;
+                        let funder = self
+                            .config
+                            .polymarket_funder
+                            .clone()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("Missing POLYMARKET_FUNDER (or POLY_FUNDER)")
+                            })?;
+                        let api_key = self
+                            .config
+                            .polymarket_api_key
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("Missing POLYMARKET_API_KEY"))?;
+                        let api_secret = self
+                            .config
+                            .polymarket_api_secret
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("Missing POLYMARKET_API_SECRET"))?;
 
-        match engines_result {
-            Ok(engines) => {
-                let platform_list: Vec<Platform> = engines.iter().map(|e| e.platform()).collect();
+                        let poly_async = PolymarketAsyncClient::new(
+                            POLY_CLOB_HOST,
+                            POLYGON_CHAIN_ID,
+                            &private_key,
+                            &funder,
+                        )?;
+                        let creds = PreparedCreds::new(api_key, api_secret);
+                        let shared =
+                            Arc::new(SharedAsyncClient::new(poly_async, creds, POLYGON_CHAIN_ID));
+                        Ok((None, Some(shared)))
+                    }
+                }
+            })();
+
+        match init_res {
+            Ok((kalshi, poly)) => {
                 self.state = TraderState::Initialized {
-                    platforms: platform_list.clone(),
-                    engines,
+                    platform,
+                    kalshi,
+                    poly,
                     dry_run: effective_dry_run,
                 };
-                info!("[TRADER] Initialized successfully with platforms: {:?}", platform_list);
+                info!("[TRADER] Initialized successfully for platform {:?}", platform);
                 OutgoingMessage::InitAck {
                     success: true,
-                    platforms: platform_list,
+                    platforms: vec![platform],
                     error: None,
                 }
             }
@@ -122,6 +225,180 @@ impl Trader {
                     success: false,
                     platforms: vec![],
                     error: Some(e.to_string()),
+                }
+            }
+        }
+    }
+
+    async fn handle_execute_leg(
+        &mut self,
+        market_id: u16,
+        leg_id: String,
+        platform: Platform,
+        action: OrderAction,
+        side: OutcomeSide,
+        price: u16,
+        contracts: i64,
+        kalshi_market_ticker: Option<String>,
+        poly_token: Option<String>,
+        pair_id: Option<String>,
+        description: Option<String>,
+    ) -> OutgoingMessage {
+        let start = Instant::now();
+
+        // Log helpful metadata (also avoids unused-variable warnings in future changes)
+        debug!(
+            "[TRADER] execute_leg: market_id={} leg_id={} platform={:?} action={:?} side={:?} price={} contracts={} pair_id={:?} desc={:?}",
+            market_id, leg_id, platform, action, side, price, contracts, pair_id.as_deref(), description.as_deref()
+        );
+
+        match &self.state {
+            TraderState::Uninitialized => {
+                return OutgoingMessage::LegResult {
+                    market_id,
+                    leg_id,
+                    platform,
+                    success: false,
+                    latency_ns: start.elapsed().as_nanos() as u64,
+                    error: Some("Trader not initialized".to_string()),
+                };
+            }
+            TraderState::Error { message } => {
+                return OutgoingMessage::LegResult {
+                    market_id,
+                    leg_id,
+                    platform,
+                    success: false,
+                    latency_ns: start.elapsed().as_nanos() as u64,
+                    error: Some(format!("Trader error: {}", message)),
+                };
+            }
+            TraderState::Initialized { platform: cfg_platform, dry_run, kalshi, poly } => {
+                if *cfg_platform != platform {
+                    return OutgoingMessage::LegResult {
+                        market_id,
+                        leg_id,
+                        platform,
+                        success: false,
+                        latency_ns: start.elapsed().as_nanos() as u64,
+                        error: Some(format!("Trader is configured for {:?} only", cfg_platform)),
+                    };
+                }
+
+                // Execute the single leg on our platform.
+                let res: anyhow::Result<()> = async {
+                    match platform {
+                        Platform::Kalshi => {
+                            let ticker = kalshi_market_ticker
+                                .as_deref()
+                                .ok_or_else(|| anyhow::anyhow!("Missing kalshi_market_ticker"))?;
+                            let side_str = match side {
+                                OutcomeSide::Yes => "yes",
+                                OutcomeSide::No => "no",
+                            };
+                            if *dry_run {
+                                info!(
+                                    "[KALSHI] DRY RUN leg_id={} {} {} {}x @ {}¢",
+                                    leg_id,
+                                    match action {
+                                        OrderAction::Buy => "buy",
+                                        OrderAction::Sell => "sell",
+                                    },
+                                    side_str,
+                                    contracts,
+                                    price
+                                );
+                                Ok(())
+                            } else {
+                                let client = kalshi
+                                    .as_ref()
+                                    .ok_or_else(|| anyhow::anyhow!("Kalshi client not initialized"))?;
+                                match action {
+                                    OrderAction::Buy => {
+                                        let resp = client
+                                            .buy_ioc(ticker, side_str, price as i64, contracts)
+                                            .await?;
+                                        info!(
+                                            "[KALSHI] leg_id={} order_id={} filled={} cost={}¢",
+                                            leg_id,
+                                            resp.order.order_id,
+                                            resp.order.filled_count(),
+                                            resp.order.taker_fill_cost.unwrap_or(0)
+                                                + resp.order.maker_fill_cost.unwrap_or(0)
+                                        );
+                                    }
+                                    OrderAction::Sell => {
+                                        let resp = client
+                                            .sell_ioc(ticker, side_str, price as i64, contracts)
+                                            .await?;
+                                        info!(
+                                            "[KALSHI] leg_id={} order_id={} filled={} cost={}¢",
+                                            leg_id,
+                                            resp.order.order_id,
+                                            resp.order.filled_count(),
+                                            resp.order.taker_fill_cost.unwrap_or(0)
+                                                + resp.order.maker_fill_cost.unwrap_or(0)
+                                        );
+                                    }
+                                }
+                                Ok(())
+                            }
+                        }
+                        Platform::Polymarket => {
+                            let token = poly_token
+                                .as_deref()
+                                .ok_or_else(|| anyhow::anyhow!("Missing poly_token"))?;
+                            let p = (price as f64) / 100.0;
+                            if *dry_run {
+                                info!(
+                                    "[POLY] DRY RUN leg_id={} {:?} {:?} {}x @ {:.4}",
+                                    leg_id, action, side, contracts, p
+                                );
+                                Ok(())
+                            } else {
+                                let client = poly
+                                    .as_ref()
+                                    .ok_or_else(|| anyhow::anyhow!("Polymarket client not initialized"))?;
+                                match action {
+                                    OrderAction::Buy => {
+                                        let fill = client.buy_fak(token, p, contracts as f64).await?;
+                                        info!(
+                                            "[POLY] leg_id={} order_id={} filled={:.2} cost={:.4}",
+                                            leg_id, fill.order_id, fill.filled_size, fill.fill_cost
+                                        );
+                                    }
+                                    OrderAction::Sell => {
+                                        let fill = client.sell_fak(token, p, contracts as f64).await?;
+                                        info!(
+                                            "[POLY] leg_id={} order_id={} filled={:.2} cost={:.4}",
+                                            leg_id, fill.order_id, fill.filled_size, fill.fill_cost
+                                        );
+                                    }
+                                }
+                                Ok(())
+                            }
+                        }
+                    }
+                }
+                .await;
+
+                match res {
+                    Ok(()) => OutgoingMessage::LegResult {
+                        market_id,
+                        leg_id,
+                        platform,
+                        success: true,
+                        latency_ns: start.elapsed().as_nanos() as u64,
+                        error: None,
+                    },
+                    Err(e) => OutgoingMessage::LegResult {
+                        market_id,
+                        leg_id,
+                        platform,
+                        success: false,
+                        latency_ns: start.elapsed().as_nanos() as u64,
+                        error: Some(e.to_string()),
+                    },
                 }
             }
         }
@@ -142,136 +419,77 @@ impl Trader {
         poly_yes_token: Option<String>,
         poly_no_token: Option<String>,
     ) -> OutgoingMessage {
-        let detected_ns = self.start_time.elapsed().as_nanos() as u64;
+        // Legacy `execute` support: convert to one or two legs, and execute only for our platform.
+        let start = Instant::now();
 
-        match &self.state {
-            TraderState::Uninitialized => {
-                warn!("[TRADER] Execute request received but trader not initialized");
-                OutgoingMessage::ExecutionResult {
+        let max_contracts = (yes_size.min(no_size) / 100) as i64;
+        if max_contracts < 1 {
+            return OutgoingMessage::ExecutionResult {
+                market_id,
+                success: false,
+                profit_cents: 0,
+                latency_ns: start.elapsed().as_nanos() as u64,
+                error: Some("Insufficient liquidity".to_string()),
+            };
+        }
+
+        let legs = self.legacy_to_legs(
+            market_id,
+            arb_type,
+            yes_price,
+            no_price,
+            max_contracts,
+            kalshi_market_ticker.clone(),
+            poly_yes_token.clone(),
+            poly_no_token.clone(),
+            pair_id.clone(),
+            description.clone(),
+        );
+
+        if legs.is_empty() {
+            return OutgoingMessage::ExecutionResult {
+                market_id,
+                success: false,
+                profit_cents: 0,
+                latency_ns: start.elapsed().as_nanos() as u64,
+                error: Some("No executable legs for this trader".to_string()),
+            };
+        }
+
+        // Execute sequentially; aggregate result.
+        for (leg_id, platform, action, side, price, contracts, kalshi_ticker, poly_token) in legs {
+            let res = self
+                .handle_execute_leg(
+                    market_id,
+                    leg_id,
+                    platform,
+                    action,
+                    side,
+                    price,
+                    contracts,
+                    kalshi_ticker,
+                    poly_token,
+                    pair_id.clone(),
+                    description.clone(),
+                )
+                .await;
+            if let OutgoingMessage::LegResult { success: false, error, .. } = res {
+                return OutgoingMessage::ExecutionResult {
                     market_id,
                     success: false,
                     profit_cents: 0,
-                    latency_ns: detected_ns,
-                    error: Some("Trader not initialized".to_string()),
-                }
-            }
-            TraderState::Error { message } => {
-                warn!("[TRADER] Execute request received but trader in error state: {}", message);
-                OutgoingMessage::ExecutionResult {
-                    market_id,
-                    success: false,
-                    profit_cents: 0,
-                    latency_ns: detected_ns,
-                    error: Some(format!("Trader error: {}", message)),
-                }
-            }
-            TraderState::Initialized {
-                engines,
-                dry_run,
-                ..
-            } => {
-                let request = OrderRequest {
-                    market_id,
-                    arb_type,
-                    yes_price,
-                    no_price,
-                    yes_size,
-                    no_size,
-                    pair_id,
-                    description,
-                    kalshi_market_ticker,
-                    poly_yes_token,
-                    poly_no_token,
+                    latency_ns: start.elapsed().as_nanos() as u64,
+                    error,
                 };
-
-                // Touch optional metadata (keeps warnings clean and helps debugging)
-                debug!(
-                    "[TRADER] Execute metadata: pair_id={:?}, description={:?}",
-                    request.pair_id.as_deref(),
-                    request.description.as_deref()
-                );
-
-                // Determine which engine(s) to use based on arb_type
-                let relevant_engines: Vec<&Box<dyn ExecutionEngine>> = engines
-                    .iter()
-                    .filter(|e| match arb_type {
-                        ArbType::PolyYesKalshiNo => {
-                            e.platform() == Platform::Polymarket || e.platform() == Platform::Kalshi
-                        }
-                        ArbType::KalshiYesPolyNo => {
-                            e.platform() == Platform::Kalshi || e.platform() == Platform::Polymarket
-                        }
-                        ArbType::PolyOnly => e.platform() == Platform::Polymarket,
-                        ArbType::KalshiOnly => e.platform() == Platform::Kalshi,
-                    })
-                    .collect();
-
-                if relevant_engines.is_empty() {
-                    warn!(
-                        "[TRADER] No suitable engine for arb_type {:?} with available platforms",
-                        arb_type
-                    );
-                    return OutgoingMessage::ExecutionResult {
-                        market_id,
-                        success: false,
-                        profit_cents: 0,
-                        latency_ns: detected_ns,
-                        error: Some("No suitable execution engine".to_string()),
-                    };
-                }
-
-                // Execute on all relevant engines
-                // For cross-platform arbs, we need to coordinate execution
-                let mut results = Vec::new();
-                for engine in relevant_engines {
-                    // Optional pre-flight checks (circuit breaker / rate limits / etc.)
-                    let est_size = (request.yes_size.min(request.no_size) / 100) as i64;
-                    if let Err(e) = engine.can_execute(request.market_id, est_size).await {
-                        warn!("[TRADER] Engine pre-check failed: {}", e);
-                        return OutgoingMessage::ExecutionResult {
-                            market_id,
-                            success: false,
-                            profit_cents: 0,
-                            latency_ns: detected_ns,
-                            error: Some(e.to_string()),
-                        };
-                    }
-
-                    match engine.execute_order(&request, *dry_run).await {
-                        Ok(result) => results.push(result),
-                        Err(e) => {
-                            error!("[TRADER] Execution error: {}", e);
-                            return OutgoingMessage::ExecutionResult {
-                                market_id,
-                                success: false,
-                                profit_cents: 0,
-                                latency_ns: detected_ns,
-                                error: Some(e.to_string()),
-                            };
-                        }
-                    }
-                }
-
-                // Combine results (for now, use the first result)
-                // In a full implementation, we'd combine cross-platform results
-                if let Some(result) = results.first() {
-                    OutgoingMessage::ExecutionResult {
-                        market_id: result.market_id,
-                        success: result.success,
-                        profit_cents: result.profit_cents,
-                        latency_ns: result.latency_ns,
-                        error: result.error.clone(),
-                    }
-                } else {
-                    OutgoingMessage::ExecutionResult {
-                        market_id,
-                        success: false,
-                        profit_cents: 0,
-                        latency_ns: detected_ns,
-                        error: Some("No execution results".to_string()),
-                    }
-                }
             }
+        }
+
+        OutgoingMessage::ExecutionResult {
+            market_id,
+            success: true,
+            profit_cents: 0,
+            latency_ns: start.elapsed().as_nanos() as u64,
+            error: Some("LEGACY_EXECUTE".to_string()),
         }
     }
 
@@ -289,12 +507,12 @@ impl Trader {
                 dry_run: self.config.dry_run,
             },
             TraderState::Initialized {
-                platforms,
+                platform,
                 dry_run,
                 ..
             } => OutgoingMessage::Status {
                 connected: true,
-                platforms: platforms.clone(),
+                platforms: vec![*platform],
                 dry_run: *dry_run,
             },
             TraderState::Error { .. } => OutgoingMessage::Status {
@@ -309,5 +527,127 @@ impl Trader {
     #[allow(dead_code)] // Used by some integrations/tests
     pub fn state(&self) -> &TraderState {
         &self.state
+    }
+}
+
+impl Trader {
+    /// Convert legacy Execute messages into single-leg instructions for this trader.
+    /// Returns tuples: (leg_id, platform, action, side, price, contracts, kalshi_ticker, poly_token)
+    fn legacy_to_legs(
+        &self,
+        market_id: u16,
+        arb_type: ArbType,
+        yes_price: u16,
+        no_price: u16,
+        contracts: i64,
+        kalshi_market_ticker: Option<String>,
+        poly_yes_token: Option<String>,
+        poly_no_token: Option<String>,
+        _pair_id: Option<String>,
+        _description: Option<String>,
+    ) -> Vec<(String, Platform, OrderAction, OutcomeSide, u16, i64, Option<String>, Option<String>)> {
+        let platform = self.config.platform;
+        let mk = |suffix: &str| format!("legacy-m{}-{}", market_id, suffix);
+
+        match arb_type {
+            ArbType::PolyYesKalshiNo => match platform {
+                Platform::Polymarket => vec![(
+                    mk("poly-yes"),
+                    Platform::Polymarket,
+                    OrderAction::Buy,
+                    OutcomeSide::Yes,
+                    yes_price,
+                    contracts,
+                    None,
+                    poly_yes_token,
+                )],
+                Platform::Kalshi => vec![(
+                    mk("kalshi-no"),
+                    Platform::Kalshi,
+                    OrderAction::Buy,
+                    OutcomeSide::No,
+                    no_price,
+                    contracts,
+                    kalshi_market_ticker,
+                    None,
+                )],
+            },
+            ArbType::KalshiYesPolyNo => match platform {
+                Platform::Kalshi => vec![(
+                    mk("kalshi-yes"),
+                    Platform::Kalshi,
+                    OrderAction::Buy,
+                    OutcomeSide::Yes,
+                    yes_price,
+                    contracts,
+                    kalshi_market_ticker,
+                    None,
+                )],
+                Platform::Polymarket => vec![(
+                    mk("poly-no"),
+                    Platform::Polymarket,
+                    OrderAction::Buy,
+                    OutcomeSide::No,
+                    no_price,
+                    contracts,
+                    None,
+                    poly_no_token,
+                )],
+            },
+            ArbType::PolyOnly => {
+                if platform != Platform::Polymarket {
+                    return vec![];
+                }
+                vec![
+                    (
+                        mk("poly-yes"),
+                        Platform::Polymarket,
+                        OrderAction::Buy,
+                        OutcomeSide::Yes,
+                        yes_price,
+                        contracts,
+                        None,
+                        poly_yes_token,
+                    ),
+                    (
+                        mk("poly-no"),
+                        Platform::Polymarket,
+                        OrderAction::Buy,
+                        OutcomeSide::No,
+                        no_price,
+                        contracts,
+                        None,
+                        poly_no_token,
+                    ),
+                ]
+            }
+            ArbType::KalshiOnly => {
+                if platform != Platform::Kalshi {
+                    return vec![];
+                }
+                vec![
+                    (
+                        mk("kalshi-yes"),
+                        Platform::Kalshi,
+                        OrderAction::Buy,
+                        OutcomeSide::Yes,
+                        yes_price,
+                        contracts,
+                        kalshi_market_ticker.clone(),
+                        None,
+                    ),
+                    (
+                        mk("kalshi-no"),
+                        Platform::Kalshi,
+                        OrderAction::Buy,
+                        OutcomeSide::No,
+                        no_price,
+                        contracts,
+                        kalshi_market_ticker,
+                        None,
+                    ),
+                ]
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add leg-based remote execution (execute_leg) and per-platform routing (Kalshi vs Polymarket).
- Enforce that each remote trader executes only its configured platform (TRADER_PLATFORM).
- Controller only dispatches cross-platform arbs when both platform traders are connected; same-platform arbs send both legs to the single trader.

## Test plan
- cargo test -p controller
- cargo build -p remote-trader --release
