### PR TITLE
feat(trader): add Polymarket manual trade mode and signature type

### DIFF
--- a/trader/README.md
+++ b/trader/README.md
@@ -34,10 +34,12 @@ Set `WEBSOCKET_URL` to the controller’s reachable address:
   - `KALSHI_API_KEY`
   - `KALSHI_PRIVATE_KEY` (PEM contents, not a path)
 - **Polymarket**
-  - `POLYMARKET_PRIVATE_KEY`
-  - `POLYMARKET_API_KEY`
-  - `POLYMARKET_API_SECRET`
+  - `POLY_PRIVATE_KEY`
   - `POLYMARKET_FUNDER` (or `POLY_FUNDER`)
+  - `POLY_SIGNATURE_TYPE` *(optional; default `0`)*
+  - `POLYMARKET_API_KEY` *(optional; will be derived if omitted)*
+  - `POLYMARKET_API_SECRET` *(optional; will be derived if omitted)*
+  - `POLYMARKET_API_PASSPHRASE` *(optional; will be derived if omitted)*
 
 ## Run examples
 
@@ -52,3 +54,96 @@ DRY_RUN=1 WEBSOCKET_URL=ws://<CONTROLLER_IP>:9001 RUST_LOG=info cargo run -p rem
 ```bash
 DRY_RUN=1 ONE_SHOT=1 WEBSOCKET_URL=ws://127.0.0.1:9001 RUST_LOG=info cargo run -p remote-trader
 ```
+
+## Manual trade mode (no controller)
+
+This mode is for validating that the **Polymarket execution path works end-to-end** by simulating the same message handling path the controller uses (`Init` → `ExecuteLeg`).
+
+**Requirements (Polymarket):**
+- `TRADER_PLATFORM=polymarket`
+- `POLY_PRIVATE_KEY`
+- `POLYMARKET_FUNDER` (or `POLY_FUNDER`)
+
+If your **funder** address (from the Polymarket UI) is **different** from the address derived from your private key (the signer), set `POLY_SIGNATURE_TYPE` to match your account type:
+- `0` = EOA (signer == funder)
+- `1`/`2` = proxy/delegated (signer != funder)
+
+The trader will auto-derive `POLYMARKET_API_KEY` / `POLYMARKET_API_SECRET` / `POLYMARKET_API_PASSPHRASE` from your wallet if you don’t provide them.
+
+If you see an error like `derive-api-key failed: 400 Bad Request {"error":"Could not derive api key!"}`, then Polymarket did not allow auto-derivation for that wallet/account. In that case, you must set:
+- `POLYMARKET_API_KEY`
+- `POLYMARKET_API_SECRET`
+- `POLYMARKET_API_PASSPHRASE`
+
+### Manual trade (step-by-step)
+
+1. **Pick the right token id**
+   - Find the market’s `clobTokenIds` (see section below).
+   - Choose the token that corresponds to the outcome you want (based on the `outcomes` array order).
+
+2. **Set env vars**
+   - Start with `DRY_RUN=1` to verify logs, then switch to `DRY_RUN=0` to place a real order.
+   - If PowerShell has `DRY_RUN` set, it can override `.env`. Unset with `Remove-Item Env:DRY_RUN`.
+
+3. **Run `manual-trade`**
+   - `--limit-price-cents` must be an **integer** number of cents (e.g. `63` = $0.63). Decimals like `99.8` are not accepted.
+   - You must pass **either** `--contracts` or `--spend-usd`.
+
+**PowerShell example (live):**
+
+```powershell
+$env:TRADER_PLATFORM="polymarket"
+$env:DRY_RUN="0"
+$env:RUST_LOG="info"
+
+# Optional: only needed if signer != funder (proxy/delegated accounts)
+$env:POLY_SIGNATURE_TYPE="2"
+
+cargo run -p remote-trader --release -- manual-trade `
+  --poly-token <CLOB_TOKEN_ID> `
+  --side yes `
+  --limit-price-cents 63 `
+  --spend-usd 2
+```
+
+**Example (dry run):**
+
+```bash
+TRADER_PLATFORM=polymarket DRY_RUN=1 RUST_LOG=info \
+cargo run -p remote-trader --release -- manual-trade \
+  --poly-token <CLOB_TOKEN_ID> \
+  --side yes \
+  --limit-price-cents 60 \
+  --contracts 10
+```
+
+**Example (live):**
+
+```bash
+TRADER_PLATFORM=polymarket DRY_RUN=0 RUST_LOG=info \
+cargo run -p remote-trader --release -- manual-trade \
+  --poly-token <CLOB_TOKEN_ID> \
+  --side yes \
+  --limit-price-cents 60 \
+  --spend-usd 5
+```
+
+### How to get the Polymarket CLOB token id (`clobTokenIds`)
+
+`--poly-token` expects Polymarket’s **CLOB `tokenId`** (a **decimal** string like `"123456..."`, **not** `0x...`).
+
+**Method A: Polymarket URL slug → Gamma API**
+
+1. Open the market on Polymarket and copy the **slug** from the URL (the last part).
+2. Open (replace `<SLUG>`):
+   - `https://gamma-api.polymarket.com/markets?slug=<SLUG>`
+3. In the JSON response, find **`clobTokenIds`** (and `outcomes`).
+   - `clobTokenIds` is a JSON string that contains an array, e.g. `["123...","456..."]`.
+4. Use the token that matches the outcome you want (check the `outcomes` array order).
+
+**Method B: Browser DevTools**
+
+1. Open the market page.
+2. Press **F12** → **Network** tab → refresh.
+3. Filter for `gamma` / `markets`, open the request to `gamma-api.polymarket.com`.
+4. In the **Response/Preview**, search for **`clobTokenIds`** and copy the token you need.

--- a/trader/src/config.rs
+++ b/trader/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub polymarket_api_secret: Option<String>,
     pub polymarket_api_passphrase: Option<String>,
     pub polymarket_funder: Option<String>,
+    /// Polymarket CLOB signature type (0=EOA, 1/2=proxy modes).
+    pub polymarket_signature_type: i32,
     pub dry_run: bool,
     /// Which platform this trader is allowed to execute on.
     pub platform: Platform,
@@ -28,13 +30,19 @@ impl Config {
         crate::paths::load_dotenv();
         let kalshi_api_key = env::var("KALSHI_API_KEY").ok();
         let kalshi_private_key = env::var("KALSHI_PRIVATE_KEY").ok();
-        let polymarket_private_key = env::var("POLYMARKET_PRIVATE_KEY").ok();
+        // Match controller `.env` naming.
+        let polymarket_private_key = env::var("POLY_PRIVATE_KEY").ok();
         let polymarket_api_key = env::var("POLYMARKET_API_KEY").ok();
         let polymarket_api_secret = env::var("POLYMARKET_API_SECRET").ok();
         let polymarket_api_passphrase = env::var("POLYMARKET_API_PASSPHRASE").ok();
         let polymarket_funder = env::var("POLYMARKET_FUNDER")
             .or_else(|_| env::var("POLY_FUNDER"))
             .ok();
+        let polymarket_signature_type: i32 = env::var("POLY_SIGNATURE_TYPE")
+            .or_else(|_| env::var("POLYMARKET_SIGNATURE_TYPE"))
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
 
         let dry_run = env::var("DRY_RUN")
             .map(|v| v == "1" || v == "true" || v == "yes")
@@ -71,6 +79,7 @@ impl Config {
             polymarket_api_secret,
             polymarket_api_passphrase,
             polymarket_funder,
+            polymarket_signature_type,
             dry_run,
             platform,
             websocket_url,

--- a/trader/src/main.rs
+++ b/trader/src/main.rs
@@ -16,6 +16,153 @@ use protocol::IncomingMessage;
 use trader::Trader;
 use websocket::WebSocketClient;
 
+fn parse_bool_env(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| v == "1" || v == "true" || v == "yes")
+        .unwrap_or(false)
+}
+
+/// Minimal CLI parser: expects `--key value` pairs.
+fn arg_value(args: &[String], key: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == key)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|a| a == flag)
+}
+
+fn usage_manual_trade() -> String {
+    [
+        "Manual trade mode (simulates controller messages):",
+        "",
+        "  cargo run -p remote-trader --release -- manual-trade \\",
+        "    --poly-token <CLOB_TOKEN_ID> \\",
+        "    --side <yes|no> \\",
+        "    --limit-price-cents <0-100> \\",
+        "    --contracts <INT>",
+        "",
+        "Or specify a USD spend amount (requires limit price):",
+        "",
+        "  cargo run -p remote-trader --release -- manual-trade \\",
+        "    --poly-token <CLOB_TOKEN_ID> \\",
+        "    --side <yes|no> \\",
+        "    --limit-price-cents <0-100> \\",
+        "    --spend-usd <FLOAT>",
+        "",
+        "Notes:",
+        "  - Live trading requires DRY_RUN=0 and Polymarket creds in env.",
+        "  - `--side` is for logging; the token determines the outcome you trade.",
+    ]
+    .join("\n")
+}
+
+async fn maybe_run_manual_trade(config: Arc<Config>) -> Result<Option<()>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    // Enable via either: `manual-trade` subcommand OR env var.
+    let is_manual = args.first().is_some_and(|a| a == "manual-trade")
+        || parse_bool_env("MANUAL_TRADE");
+    if !is_manual {
+        return Ok(None);
+    }
+
+    if has_flag(&args, "--help") || has_flag(&args, "-h") {
+        println!("{}", usage_manual_trade());
+        return Ok(Some(()));
+    }
+
+    // This is intended for validating the Polymarket executor path.
+    if config.platform != crate::protocol::Platform::Polymarket {
+        anyhow::bail!(
+            "manual-trade requires TRADER_PLATFORM=polymarket (current={:?})",
+            config.platform
+        );
+    }
+
+    let poly_token = arg_value(&args, "--poly-token")
+        .ok_or_else(|| anyhow::anyhow!("Missing --poly-token\n\n{}", usage_manual_trade()))?;
+
+    let side_str = arg_value(&args, "--side")
+        .ok_or_else(|| anyhow::anyhow!("Missing --side\n\n{}", usage_manual_trade()))?;
+    let side = match side_str.as_str() {
+        "yes" | "YES" | "Yes" => crate::protocol::OutcomeSide::Yes,
+        "no" | "NO" | "No" => crate::protocol::OutcomeSide::No,
+        other => anyhow::bail!("Invalid --side: {} (expected yes|no)", other),
+    };
+
+    let limit_price_cents: u16 = arg_value(&args, "--limit-price-cents")
+        .ok_or_else(|| anyhow::anyhow!("Missing --limit-price-cents\n\n{}", usage_manual_trade()))?
+        .parse()
+        .context("Failed to parse --limit-price-cents as integer")?;
+    if limit_price_cents > 100 {
+        anyhow::bail!("--limit-price-cents must be 0..=100");
+    }
+
+    let contracts: i64 = if let Some(c) = arg_value(&args, "--contracts") {
+        c.parse().context("Failed to parse --contracts as integer")?
+    } else if let Some(spend) = arg_value(&args, "--spend-usd") {
+        let spend_usd: f64 = spend.parse().context("Failed to parse --spend-usd as float")?;
+        let px = (limit_price_cents as f64) / 100.0;
+        if px <= 0.0 {
+            anyhow::bail!("--limit-price-cents must be > 0 when using --spend-usd");
+        }
+        let c = (spend_usd / px).floor() as i64;
+        c
+    } else {
+        return Err(anyhow::anyhow!(
+            "Missing --contracts or --spend-usd\n\n{}",
+            usage_manual_trade()
+        ));
+    };
+
+    if contracts < 1 {
+        anyhow::bail!("Computed contracts < 1; increase --contracts or --spend-usd");
+    }
+
+    info!(
+        "[MANUAL] Starting manual-trade: poly_token={} side={:?} limit={}c contracts={} dry_run={}",
+        poly_token, side, limit_price_cents, contracts, config.dry_run
+    );
+
+    // Simulate controller Init + ExecuteLeg messages (same trader codepath).
+    let mut trader = Trader::new(config.clone());
+
+    let init_ack = trader
+        .handle_message(IncomingMessage::Init {
+            platforms: vec![crate::protocol::Platform::Polymarket],
+            dry_run: config.dry_run,
+        })
+        .await;
+    info!("[MANUAL] init_ack={:?}", init_ack);
+
+    let ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let leg_id = format!("manual-{}", ms);
+    let res = trader
+        .handle_message(IncomingMessage::ExecuteLeg {
+            market_id: 0,
+            leg_id,
+            platform: crate::protocol::Platform::Polymarket,
+            action: crate::protocol::OrderAction::Buy,
+            side,
+            price: limit_price_cents,
+            contracts,
+            kalshi_market_ticker: None,
+            poly_token: Some(poly_token),
+            pair_id: Some("MANUAL_TRADE".to_string()),
+            description: Some("manual-trade".to_string()),
+        })
+        .await;
+
+    info!("[MANUAL] execute_leg_result={:?}", res);
+    Ok(Some(()))
+}
+
 /// Discover controller via Tailscale beacon or use configured URL
 async fn resolve_websocket_url(config: &Config) -> Result<String> {
     // If WEBSOCKET_URL is set, use it directly
@@ -102,6 +249,11 @@ async fn main() -> Result<()> {
     // Load configuration
     let config = Arc::new(Config::from_env().context("Failed to load configuration")?);
     info!("[MAIN] Configuration loaded (dry_run={})", config.dry_run);
+
+    // Optional "manual trade" mode for validating live execution without a controller.
+    if let Some(()) = maybe_run_manual_trade(config.clone()).await? {
+        return Ok(());
+    }
 
     // Create trader
     let mut trader = Trader::new(config.clone());


### PR DESCRIPTION
- Add manual-trade CLI to simulate controller Init + ExecuteLeg flow.
- Support POLY_SIGNATURE_TYPE/POLYMARKET_SIGNATURE_TYPE for proxy/delegated accounts.
- Align env var naming to POLY_PRIVATE_KEY and auto-derive Polymarket API creds when unset.