### PR TITLE
refactor(tests): update mock module documentation and suppress dead c…

### DIFF
--- a/controller/src/bin/generate_team_cache.rs
+++ b/controller/src/bin/generate_team_cache.rs
@@ -60,13 +60,11 @@ const KNOWN_MAPPINGS: &[(&str, &str, &str)] = &[
 #[derive(Debug, Deserialize)]
 struct PolyEvent {
     slug: Option<String>,
-    title: Option<String>,
     markets: Option<Vec<PolyMarket>>,
 }
 
 #[derive(Debug, Deserialize)]
 struct PolyMarket {
-    slug: Option<String>,
     outcomes: Option<String>,
 }
 

--- a/controller/src/poly_executor.rs
+++ b/controller/src/poly_executor.rs
@@ -45,7 +45,12 @@ pub trait PolyExecutor: Send + Sync {
 // MOCK IMPLEMENTATION (FOR TESTING)
 // =============================================================================
 
-/// Mock module for testing. Available in all builds but only used in tests.
+/// Mock implementation used by integration tests.
+///
+/// This code lives in the main crate so integration tests can import it, but it
+/// is not referenced by normal binaries. Suppress `dead_code` warnings for the
+/// module as a whole.
+#[allow(dead_code)]
 pub mod mock {
     use super::*;
     use anyhow::anyhow;


### PR DESCRIPTION
…ode warnings

- Clarified the purpose of the mock module for integration tests.
- Added `#[allow(dead_code)]` to suppress warnings for unused code in the module.
- Removed unused fields from `PolyEvent` and `PolyMarket` structs to streamline the code.