### PR TITLE
refactor: consolidate FastExecutionRequest into ArbOpportunity

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "rust-analyzer": {
+      "command": "rust-analyzer-mcp"
+    }
+  }
+}

--- a/controller/src/arb.rs
+++ b/controller/src/arb.rs
@@ -1,0 +1,236 @@
+//! Centralized arbitrage configuration and fee calculation.
+//!
+//! Arb detection logic lives in `ArbOpportunity::detect()`.
+//! This module provides:
+//! - `ArbConfig` - threshold and min_contracts configuration
+//! - `kalshi_fee()` - Kalshi fee calculation
+
+use crate::types::PriceCents;
+
+/// Calculate Kalshi trading fee in cents for a single contract at the given price.
+/// Formula: ceil(0.07 * price * (1 - price/100)) in cents
+/// Using integer math: (7 * p * (100 - p) + 9999) / 10000
+#[inline]
+pub fn kalshi_fee(price_cents: PriceCents) -> PriceCents {
+    if price_cents == 0 || price_cents >= 100 {
+        return 0;
+    }
+    let p = price_cents as u32;
+    ((7 * p * (100 - p) + 9999) / 10000) as PriceCents
+}
+
+/// Configuration for arbitrage detection.
+///
+/// Loaded from environment variables at startup with sensible defaults.
+/// Fields are private to enforce invariants; use getter methods for access.
+#[derive(Debug, Clone)]
+pub struct ArbConfig {
+    /// Threshold in cents below which an arb is considered profitable.
+    /// Valid range: 1-100 (default: 99)
+    threshold_cents: PriceCents,
+    /// Minimum number of contracts to execute.
+    /// Must be > 0 (default: 1.0)
+    min_contracts: f64,
+}
+
+impl ArbConfig {
+    /// Create a new ArbConfig with validation.
+    ///
+    /// # Arguments
+    /// * `threshold_cents` - Maximum cost for a profitable arb (1-100)
+    /// * `min_contracts` - Minimum contracts to execute (must be > 0)
+    ///
+    /// # Panics
+    /// Panics in debug mode if values are out of valid range.
+    pub fn new(threshold_cents: PriceCents, min_contracts: f64) -> Self {
+        debug_assert!(
+            threshold_cents > 0 && threshold_cents <= 100,
+            "threshold_cents must be in range 1-100, got {}",
+            threshold_cents
+        );
+        debug_assert!(
+            min_contracts > 0.0,
+            "min_contracts must be > 0, got {}",
+            min_contracts
+        );
+
+        Self {
+            threshold_cents,
+            min_contracts,
+        }
+    }
+
+    /// Load configuration from environment variables with validation.
+    ///
+    /// Reads:
+    /// - `ARB_THRESHOLD_CENTS`: Threshold in cents (default: 99, valid: 1-100)
+    /// - `ARB_MIN_CONTRACTS`: Minimum contracts to execute (default: 1.0, must be > 0)
+    ///
+    /// Invalid values are logged and replaced with defaults.
+    pub fn from_env() -> Self {
+        let threshold_cents = std::env::var("ARB_THRESHOLD_CENTS")
+            .ok()
+            .and_then(|s| s.parse::<PriceCents>().ok())
+            .map(|v| {
+                if v == 0 || v > 100 {
+                    tracing::warn!(
+                        "[ARB] ARB_THRESHOLD_CENTS={} out of range (1-100), using default 99",
+                        v
+                    );
+                    99
+                } else {
+                    v
+                }
+            })
+            .unwrap_or(99);
+
+        let min_contracts = std::env::var("ARB_MIN_CONTRACTS")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .map(|v| {
+                if v <= 0.0 {
+                    tracing::warn!(
+                        "[ARB] ARB_MIN_CONTRACTS={} must be > 0, using default 1.0",
+                        v
+                    );
+                    1.0
+                } else {
+                    v
+                }
+            })
+            .unwrap_or(1.0);
+
+        Self {
+            threshold_cents,
+            min_contracts,
+        }
+    }
+
+    /// Returns the threshold in cents for profitable arbs.
+    #[inline]
+    pub fn threshold_cents(&self) -> PriceCents {
+        self.threshold_cents
+    }
+
+    /// Returns the minimum number of contracts required.
+    #[inline]
+    pub fn min_contracts(&self) -> f64 {
+        self.min_contracts
+    }
+}
+
+impl Default for ArbConfig {
+    fn default() -> Self {
+        Self {
+            threshold_cents: 99,
+            min_contracts: 1.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // ArbConfig Tests
+    // =========================================================================
+
+    #[test]
+    fn test_arb_config_defaults() {
+        let config = ArbConfig::default();
+
+        assert_eq!(config.threshold_cents(), 99);
+        assert_eq!(config.min_contracts(), 1.0);
+    }
+
+    #[test]
+    fn test_arb_config_from_env() {
+        // Set environment variables
+        std::env::set_var("ARB_THRESHOLD_CENTS", "95");
+        std::env::set_var("ARB_MIN_CONTRACTS", "5.0");
+
+        let config = ArbConfig::from_env();
+
+        assert_eq!(config.threshold_cents(), 95);
+        assert_eq!(config.min_contracts(), 5.0);
+
+        // Clean up environment variables
+        std::env::remove_var("ARB_THRESHOLD_CENTS");
+        std::env::remove_var("ARB_MIN_CONTRACTS");
+    }
+
+    #[test]
+    fn test_arb_config_new_with_valid_values() {
+        let config = ArbConfig::new(95, 2.5);
+
+        assert_eq!(config.threshold_cents(), 95);
+        assert_eq!(config.min_contracts(), 2.5);
+    }
+
+    #[test]
+    fn test_arb_config_from_env_validates_threshold() {
+        // Set invalid threshold (0)
+        std::env::set_var("ARB_THRESHOLD_CENTS", "0");
+        std::env::remove_var("ARB_MIN_CONTRACTS");
+
+        let config = ArbConfig::from_env();
+
+        // Should fall back to default 99
+        assert_eq!(config.threshold_cents(), 99);
+
+        // Clean up
+        std::env::remove_var("ARB_THRESHOLD_CENTS");
+    }
+
+    #[test]
+    fn test_arb_config_from_env_validates_min_contracts() {
+        // Set invalid min_contracts (negative)
+        std::env::remove_var("ARB_THRESHOLD_CENTS");
+        std::env::set_var("ARB_MIN_CONTRACTS", "-1.0");
+
+        let config = ArbConfig::from_env();
+
+        // Should fall back to default 1.0
+        assert_eq!(config.min_contracts(), 1.0);
+
+        // Clean up
+        std::env::remove_var("ARB_MIN_CONTRACTS");
+    }
+
+    // =========================================================================
+    // kalshi_fee Tests
+    // =========================================================================
+
+    #[test]
+    fn test_kalshi_fee_zero_price() {
+        assert_eq!(kalshi_fee(0), 0, "Fee should be 0 for price 0");
+    }
+
+    #[test]
+    fn test_kalshi_fee_price_100() {
+        assert_eq!(kalshi_fee(100), 0, "Fee should be 0 for price 100 (no risk)");
+    }
+
+    #[test]
+    fn test_kalshi_fee_price_above_100() {
+        // Prices above 100 are invalid but should still be handled gracefully
+        assert_eq!(kalshi_fee(101), 0, "Fee should be 0 for price > 100");
+        assert_eq!(kalshi_fee(u16::MAX), 0, "Fee should be 0 for extreme price");
+    }
+
+    #[test]
+    fn test_kalshi_fee_known_values() {
+        // Fee formula: ceil(7 * p * (100 - p) / 10000)
+        // At p=50: 7 * 50 * 50 / 10000 = 17500 / 10000 = 1.75 -> ceil = 2
+        assert_eq!(kalshi_fee(50), 2);
+        // At p=10: 7 * 10 * 90 / 10000 = 6300 / 10000 = 0.63 -> ceil = 1
+        assert_eq!(kalshi_fee(10), 1);
+        // At p=90: 7 * 90 * 10 / 10000 = 6300 / 10000 = 0.63 -> ceil = 1
+        assert_eq!(kalshi_fee(90), 1);
+        // At p=1: 7 * 1 * 99 / 10000 = 693 / 10000 = 0.0693 -> ceil = 1
+        assert_eq!(kalshi_fee(1), 1);
+        // At p=99: 7 * 99 * 1 / 10000 = 693 / 10000 = 0.0693 -> ceil = 1
+        assert_eq!(kalshi_fee(99), 1);
+    }
+}

--- a/controller/src/confirm_log.rs
+++ b/controller/src/confirm_log.rs
@@ -40,7 +40,7 @@ pub struct ConfirmationRecord {
     pub yes_price_cents: u16,
     pub no_price_cents: u16,
     pub profit_cents: i16,
-    pub max_contracts: i64,
+    pub max_contracts: u16,
     pub detection_count: u32,
     pub kalshi_url: String,
     pub poly_url: String,
@@ -93,7 +93,8 @@ impl ConfirmationLogger {
         &self.file_path
     }
 
-    /// Get the number of records logged
+    /// Get the number of records logged.
+    /// Useful for summary statistics when closing a confirmation session.
     #[allow(dead_code)]
     pub fn record_count(&self) -> usize {
         self.record_count

--- a/controller/src/confirm_queue.rs
+++ b/controller/src/confirm_queue.rs
@@ -7,14 +7,15 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock};
+use crate::arb::kalshi_fee;
 use crate::config::{build_polymarket_url, KALSHI_WEB_BASE};
-use crate::types::{ArbType, FastExecutionRequest, GlobalState, MarketPair, PriceCents, kalshi_fee_cents};
+use crate::types::{ArbType, ArbOpportunity, GlobalState, MarketPair, PriceCents};
 
 /// A pending arbitrage opportunity awaiting confirmation
 #[derive(Debug, Clone)]
 pub struct PendingArb {
     /// Original execution request
-    pub request: FastExecutionRequest,
+    pub request: ArbOpportunity,
     /// Market pair info (for display)
     pub pair: Arc<MarketPair>,
     /// Number of times this arb has been detected while pending
@@ -31,7 +32,7 @@ pub struct PendingArb {
 }
 
 impl PendingArb {
-    pub fn new(request: FastExecutionRequest, pair: Arc<MarketPair>) -> Self {
+    pub fn new(request: ArbOpportunity, pair: Arc<MarketPair>) -> Self {
         let kalshi_url = format!("{}/{}", KALSHI_WEB_BASE, pair.kalshi_market_ticker);
         let poly_url = build_polymarket_url(&pair.league, &pair.poly_slug);
         let now = Instant::now();
@@ -48,7 +49,7 @@ impl PendingArb {
     }
 
     /// Update with fresher price data
-    pub fn update(&mut self, request: FastExecutionRequest) {
+    pub fn update(&mut self, request: ArbOpportunity) {
         self.request = request;
         self.detection_count += 1;
         self.last_detected = Instant::now();
@@ -59,9 +60,10 @@ impl PendingArb {
         self.request.profit_cents()
     }
 
-    /// Calculate max contracts from size
-    pub fn max_contracts(&self) -> i64 {
-        (self.request.yes_size.min(self.request.no_size) / 100) as i64
+    /// Calculate max contracts based on available size and prices.
+    /// Delegates to ArbOpportunity::max_contracts().
+    pub fn max_contracts(&self) -> u16 {
+        self.request.max_contracts()
     }
 }
 
@@ -115,7 +117,8 @@ impl ConfirmationQueue {
 
     /// Push a new arb opportunity (or update existing for same market).
     /// Returns `true` if this was a new entry, `false` if updating existing or blacklisted.
-    pub async fn push(&self, request: FastExecutionRequest, pair: Arc<MarketPair>) -> bool {
+    /// Note: Size validation is done upstream in ArbOpportunity::detect()
+    pub async fn push(&self, request: ArbOpportunity, pair: Arc<MarketPair>) -> bool {
         let market_id = request.market_id;
 
         // Check blacklist and clean expired entries in one lock acquisition
@@ -152,7 +155,11 @@ impl ConfirmationQueue {
         // Only notify TUI on new entries to avoid flooding with updates.
         // The TUI re-renders every 100ms anyway, so price updates will still show.
         if is_new {
-            let _ = self.update_tx.try_send(());
+            if self.update_tx.try_send(()).is_err() {
+                // Channel full or closed - TUI may be slow or shut down.
+                // Log at debug level since TUI re-renders periodically anyway.
+                tracing::debug!("[CONFIRM] TUI notification channel full or closed");
+            }
         }
 
         is_new
@@ -207,11 +214,13 @@ impl ConfirmationQueue {
     }
 
     /// Check if arb is still valid (prices haven't moved)
+    #[allow(dead_code)]
     pub fn validate_arb(&self, arb: &PendingArb) -> bool {
         self.validate_arb_detailed(arb).map(|r| r.is_valid).unwrap_or(false)
     }
 
-    /// Check if arb is still valid with detailed cost info
+    /// Check if arb is still valid with detailed cost info.
+    /// Returns None if the market is no longer in global state (race condition or state inconsistency).
     pub fn validate_arb_detailed(&self, arb: &PendingArb) -> Option<ValidationResult> {
         // Test arbs use synthetic prices, skip validation
         if arb.request.is_test {
@@ -222,7 +231,17 @@ impl ConfirmationQueue {
             });
         }
 
-        let market = self.state.get_by_id(arb.request.market_id)?;
+        let market = match self.state.get_by_id(arb.request.market_id) {
+            Some(m) => m,
+            None => {
+                tracing::warn!(
+                    "[CONFIRM] Market {} not found during validation for {}",
+                    arb.request.market_id,
+                    arb.pair.description
+                );
+                return None;
+            }
+        };
 
         // Get current prices from orderbook
         let (k_yes, k_no, _, _) = market.kalshi.load();
@@ -230,26 +249,26 @@ impl ConfirmationQueue {
 
         // Calculate original cost (from when arb was queued)
         let original_cost = arb.request.yes_price + arb.request.no_price + match arb.request.arb_type {
-            ArbType::PolyYesKalshiNo => kalshi_fee_cents(arb.request.no_price),
-            ArbType::KalshiYesPolyNo => kalshi_fee_cents(arb.request.yes_price),
+            ArbType::PolyYesKalshiNo => kalshi_fee(arb.request.no_price),
+            ArbType::KalshiYesPolyNo => kalshi_fee(arb.request.yes_price),
             ArbType::PolyOnly => 0,
-            ArbType::KalshiOnly => kalshi_fee_cents(arb.request.yes_price) + kalshi_fee_cents(arb.request.no_price),
+            ArbType::KalshiOnly => kalshi_fee(arb.request.yes_price) + kalshi_fee(arb.request.no_price),
         };
 
         // Calculate current cost based on arb type
         let current_cost = match arb.request.arb_type {
             ArbType::PolyYesKalshiNo => {
-                let fee = kalshi_fee_cents(k_no);
+                let fee = kalshi_fee(k_no);
                 p_yes + k_no + fee
             }
             ArbType::KalshiYesPolyNo => {
-                let fee = kalshi_fee_cents(k_yes);
+                let fee = kalshi_fee(k_yes);
                 k_yes + fee + p_no
             }
             ArbType::PolyOnly => p_yes + p_no,
             ArbType::KalshiOnly => {
-                let fee_yes = kalshi_fee_cents(k_yes);
-                let fee_no = kalshi_fee_cents(k_no);
+                let fee_yes = kalshi_fee(k_yes);
+                let fee_no = kalshi_fee(k_no);
                 k_yes + fee_yes + k_no + fee_no
             }
         };
@@ -268,5 +287,130 @@ impl ConfirmationQueue {
         let (k_yes, k_no, _, _) = market.kalshi.load();
         let (p_yes, p_no, _, _) = market.poly.load();
         Some((k_yes, k_no, p_yes, p_no))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::MarketType;
+
+    /// Create a test MarketPair with minimal fields
+    fn test_market_pair() -> Arc<MarketPair> {
+        Arc::new(MarketPair {
+            pair_id: "test-pair".into(),
+            league: "nba".into(),
+            market_type: MarketType::Moneyline,
+            description: "Test Market".into(),
+            kalshi_event_ticker: "KXNBA-TEST".into(),
+            kalshi_market_ticker: "KXNBA-TEST-MKT".into(),
+            kalshi_event_slug: "test-event".into(),
+            poly_slug: "nba-test-2026-01-01".into(),
+            poly_yes_token: "0x1234".into(),
+            poly_no_token: "0x5678".into(),
+            line_value: None,
+            team_suffix: None,
+        })
+    }
+
+    /// Create a test ArbOpportunity
+    fn test_request(yes_price: u16, no_price: u16, yes_size: u16, no_size: u16) -> ArbOpportunity {
+        ArbOpportunity {
+            market_id: 1,
+            yes_price,
+            no_price,
+            yes_size,
+            no_size,
+            arb_type: ArbType::PolyYesKalshiNo,
+            detected_ns: 0,
+            is_test: false,
+        }
+    }
+
+    // =========================================================================
+    // PendingArb tests
+    // =========================================================================
+
+    #[test]
+    fn test_pending_arb_max_contracts_basic() {
+        // YES: 400/40 = 10 contracts, NO: 600/50 = 12 contracts
+        // max_contracts = min(10, 12) = 10
+        let request = test_request(40, 50, 400, 600);
+        let pending = PendingArb::new(request, test_market_pair());
+
+        assert_eq!(pending.max_contracts(), 10);
+    }
+
+    #[test]
+    fn test_pending_arb_max_contracts_no_side_limiting() {
+        // YES: 800/40 = 20 contracts, NO: 250/50 = 5 contracts
+        // max_contracts = min(20, 5) = 5
+        let request = test_request(40, 50, 800, 250);
+        let pending = PendingArb::new(request, test_market_pair());
+
+        assert_eq!(pending.max_contracts(), 5);
+    }
+
+    #[test]
+    fn test_pending_arb_max_contracts_zero_yes_price() {
+        // Division by zero protection
+        let request = test_request(0, 50, 400, 600);
+        let pending = PendingArb::new(request, test_market_pair());
+
+        assert_eq!(pending.max_contracts(), 0);
+    }
+
+    #[test]
+    fn test_pending_arb_max_contracts_zero_no_price() {
+        // Division by zero protection
+        let request = test_request(40, 0, 400, 600);
+        let pending = PendingArb::new(request, test_market_pair());
+
+        assert_eq!(pending.max_contracts(), 0);
+    }
+
+    #[test]
+    fn test_pending_arb_max_contracts_both_prices_zero() {
+        let request = test_request(0, 0, 400, 600);
+        let pending = PendingArb::new(request, test_market_pair());
+
+        assert_eq!(pending.max_contracts(), 0);
+    }
+
+    #[test]
+    fn test_pending_arb_update_increments_detection_count() {
+        let request1 = test_request(40, 50, 400, 600);
+        let request2 = test_request(41, 51, 500, 700);
+        let mut pending = PendingArb::new(request1, test_market_pair());
+
+        assert_eq!(pending.detection_count, 1);
+
+        pending.update(request2);
+
+        assert_eq!(pending.detection_count, 2);
+        assert_eq!(pending.request.yes_price, 41);
+        assert_eq!(pending.request.no_price, 51);
+    }
+
+    #[test]
+    fn test_pending_arb_profit_cents_delegates_to_request() {
+        // This tests that profit_cents() correctly delegates to request.profit_cents()
+        let request = test_request(40, 50, 400, 600);
+        let pending = PendingArb::new(request.clone(), test_market_pair());
+
+        // profit_cents should match the request's calculation
+        assert_eq!(pending.profit_cents(), request.profit_cents());
+    }
+
+    #[test]
+    fn test_pending_arb_urls_constructed_correctly() {
+        let request = test_request(40, 50, 400, 600);
+        let pending = PendingArb::new(request, test_market_pair());
+
+        // Kalshi URL should contain the market ticker
+        assert!(pending.kalshi_url.contains("KXNBA-TEST-MKT"));
+
+        // Polymarket URL should be built from league and slug
+        assert!(pending.poly_url.contains("nba"));
     }
 }

--- a/controller/src/execution.rs
+++ b/controller/src/execution.rs
@@ -15,7 +15,7 @@ use crate::kalshi::KalshiApiClient;
 use crate::poly_executor::PolyExecutor;
 use crate::types::{
     ArbType, MarketPair,
-    FastExecutionRequest, GlobalState,
+    ArbOpportunity, GlobalState,
     cents_to_price,
 };
 use crate::circuit_breaker::CircuitBreaker;
@@ -131,7 +131,7 @@ impl ExecutionEngine {
 
     /// Process an execution request
     #[inline]
-    pub async fn process(&self, req: FastExecutionRequest) -> Result<ExecutionResult> {
+    pub async fn process(&self, req: ArbOpportunity) -> Result<ExecutionResult> {
         let market_id = req.market_id;
 
         // Deduplication check (512 markets via 8x u64 bitmask)
@@ -422,7 +422,7 @@ impl ExecutionEngine {
 
     async fn execute_both_legs_async(
         &self,
-        req: &FastExecutionRequest,
+        req: &ArbOpportunity,
         pair: &MarketPair,
         contracts: i64,
     ) -> Result<(i64, i64, i64, i64, String, String)> {
@@ -960,7 +960,7 @@ pub struct ExecutionResult {
 }
 
 /// Create a new execution request channel with bounded capacity
-pub fn create_execution_channel() -> (mpsc::Sender<FastExecutionRequest>, mpsc::Receiver<FastExecutionRequest>) {
+pub fn create_execution_channel() -> (mpsc::Sender<ArbOpportunity>, mpsc::Receiver<ArbOpportunity>) {
     mpsc::channel(256)
 }
 
@@ -969,7 +969,7 @@ pub fn create_execution_channel() -> (mpsc::Sender<FastExecutionRequest>, mpsc::
 /// When `log_tx` is provided and TUI is active, logs are routed through the channel
 /// instead of going to stdout (which would corrupt the TUI display).
 pub async fn run_execution_loop(
-    mut rx: mpsc::Receiver<FastExecutionRequest>,
+    mut rx: mpsc::Receiver<ArbOpportunity>,
     engine: Arc<ExecutionEngine>,
     tui_state: Option<Arc<tokio::sync::RwLock<crate::confirm_tui::TuiState>>>,
     log_tx: Option<mpsc::Sender<String>>,

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -3,6 +3,7 @@
 //! A high-performance, production-ready arbitrage trading system for cross-platform
 //! prediction markets with real-time price monitoring and execution.
 
+pub mod arb;
 pub mod cache;
 pub mod circuit_breaker;
 pub mod config;

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -22,6 +22,7 @@
 //! - **Circuit breaker protection** with configurable risk limits
 //! - **Market discovery system** with intelligent caching and incremental updates
 
+mod arb;
 mod cache;
 mod circuit_breaker;
 mod config;
@@ -68,7 +69,7 @@ use crate::remote_execution::{HybridExecutor, run_hybrid_execution_loop};
 use crate::remote_protocol::Platform as WsPlatform;
 use crate::remote_trader::RemoteTraderServer;
 use trading::execution::Platform as TradingPlatform;
-use types::{FastExecutionRequest, GlobalState, MarketPair, MarketType, PriceCents};
+use types::{ArbOpportunity, GlobalState, MarketPair, MarketType, PriceCents};
 
 /// Polymarket CLOB API host
 const POLY_CLOB_HOST: &str = "https://clob.polymarket.com";
@@ -749,9 +750,12 @@ async fn main() -> Result<()> {
     // Create Kalshi API client
     let kalshi_api = Arc::new(KalshiApiClient::new(kalshi_config));
 
-    // Build global state
+    // Build global state with arb config loaded from environment
+    let arb_config = arb::ArbConfig::from_env();
+    info!("   Arb threshold: {}¢ | min contracts: {}",
+          arb_config.threshold_cents(), arb_config.min_contracts());
     let state = Arc::new({
-        let s = GlobalState::new();
+        let s = GlobalState::new(arb_config);
         for pair in result.pairs {
             s.add_pair(pair);
         }
@@ -765,7 +769,7 @@ async fn main() -> Result<()> {
 
     // Confirmation mode setup
     let confirm_enabled = config::any_league_requires_confirmation();
-    let (confirm_tx, mut confirm_rx) = tokio::sync::mpsc::channel::<(FastExecutionRequest, Arc<MarketPair>)>(256);
+    let (confirm_tx, mut confirm_rx) = tokio::sync::mpsc::channel::<(ArbOpportunity, Arc<MarketPair>)>(256);
     let (tui_update_tx, tui_update_rx) = tokio::sync::mpsc::channel::<()>(16);
     let (tui_action_tx, mut tui_action_rx) = tokio::sync::mpsc::channel::<ConfirmAction>(16);
     let (tui_log_tx, tui_log_rx) = tokio::sync::mpsc::channel::<String>(1024);
@@ -1020,14 +1024,20 @@ async fn main() -> Result<()> {
                                     // Validate arb is still profitable
                                     match confirm_queue_clone.validate_arb_detailed(&arb) {
                                         Some(result) if result.is_valid => {
-                                            if let Err(e) = confirm_exec_tx.try_send(arb.request.clone()) {
-                                                log_msg(format!("[{}] ERROR [CONFIRM] ❌ FAILED to forward approved arb to execution: {} - {}",
-                                                    chrono::Local::now().format("%H:%M:%S"), arb.pair.description, e));
-                                            } else {
-                                                log_msg(format!("[{}]  INFO [CONFIRM] ✅ Approved: {} - forwarding to execution",
-                                                    chrono::Local::now().format("%H:%M:%S"), arb.pair.description));
+                                            match confirm_exec_tx.try_send(arb.request.clone()) {
+                                                Ok(()) => {
+                                                    log_msg(format!("[{}]  INFO [CONFIRM] ✅ Approved: {} - forwarded to execution",
+                                                        chrono::Local::now().format("%H:%M:%S"), arb.pair.description));
+                                                    ConfirmationStatus::Accepted
+                                                }
+                                                Err(e) => {
+                                                    log_msg(format!("[{}] ERROR [CONFIRM] ❌ Approved but FAILED to forward: {} - channel error: {}",
+                                                        chrono::Local::now().format("%H:%M:%S"), arb.pair.description, e));
+                                                    tracing::error!("[CONFIRM] Execution channel send failed for market {}: {}", market_id, e);
+                                                    // Return Accepted so it's logged, but the user will see the error message
+                                                    ConfirmationStatus::Accepted
+                                                }
                                             }
-                                            ConfirmationStatus::Accepted
                                         }
                                         Some(result) => {
                                             // Expired - show how much prices moved
@@ -1102,9 +1112,14 @@ async fn main() -> Result<()> {
     } else {
         // When confirm mode is disabled, drain confirm_rx and forward directly to execution
         Some(tokio::spawn(async move {
+            let mut dropped_count = 0u64;
             while let Some((req, pair)) = confirm_rx.recv().await {
                 if let Err(e) = confirm_exec_tx.try_send(req) {
-                    warn!("[CONFIRM] Failed to forward arb to execution: {} - {}", pair.description, e);
+                    dropped_count += 1;
+                    tracing::warn!(
+                        "[CONFIRM] Bypass mode: arb dropped for {} - {} (total dropped: {})",
+                        pair.description, e, dropped_count
+                    );
                 }
             }
         }))
@@ -1129,7 +1144,7 @@ async fn main() -> Result<()> {
             .unwrap_or(10);
 
         tokio::spawn(async move {
-            use types::{FastExecutionRequest, ArbType};
+            use types::{ArbOpportunity, ArbType};
 
             // Wait for WebSocket connections to establish and populate orderbooks
             info!("[TEST] Injecting synthetic arbitrage opportunity in {} seconds...", test_arb_delay);
@@ -1162,7 +1177,7 @@ async fn main() -> Result<()> {
                 if let Some(market) = test_state.get_by_id(market_id as u16) {
                     if let Some(pair) = market.pair() {
                         // SIZE: 1000 cents = 10 contracts (Poly $1 min requires ~3 contracts at 40¢)
-                        let fake_req = FastExecutionRequest {
+                        let fake_req = ArbOpportunity {
                             market_id: market_id as u16,
                             yes_price,
                             no_price,
@@ -1274,12 +1289,18 @@ async fn main() -> Result<()> {
     // This catches opportunities that existed before both platforms were fully loaded
     let sweep_state = state.clone();
     let sweep_exec_tx = exec_tx.clone();
-    let sweep_threshold = threshold_cents;
     let sweep_clock = clock.clone();
     let sweep_tui_state = tui_state.clone();
     let sweep_log_tx = tui_log_tx.clone();
     tokio::spawn(async move {
-        use crate::types::{FastExecutionRequest, ArbType};
+        // Helper closure to route log output based on TUI state
+        let log_line = |line: String, tui_active: bool| {
+            if tui_active {
+                let _ = sweep_log_tx.try_send(line);
+            } else {
+                info!("{}", line);
+            }
+        };
 
         // Helper closure to route log output based on TUI state
         let log_line = |line: String, tui_active: bool| {
@@ -1310,37 +1331,15 @@ async fn main() -> Result<()> {
             }
             markets_scanned += 1;
 
-            let arb_mask = market.check_arbs(sweep_threshold);
-            if arb_mask != 0 {
+            // Check for arbs using ArbOpportunity::detect()
+            if let Some(req) = ArbOpportunity::detect(
+                market.market_id,
+                market.kalshi.load(),
+                market.poly.load(),
+                sweep_state.arb_config(),
+                sweep_clock.now_ns(),
+            ) {
                 arbs_found += 1;
-
-                // Build execution request (same logic as send_arb_request)
-                let (k_yes, k_no, k_yes_size, k_no_size) = market.kalshi.load();
-                let (p_yes, p_no, p_yes_size, p_no_size) = market.poly.load();
-
-                let (yes_price, no_price, yes_size, no_size, arb_type) = if arb_mask & 1 != 0 {
-                    (p_yes, k_no, p_yes_size, k_no_size, ArbType::PolyYesKalshiNo)
-                } else if arb_mask & 2 != 0 {
-                    (k_yes, p_no, k_yes_size, p_no_size, ArbType::KalshiYesPolyNo)
-                } else if arb_mask & 4 != 0 {
-                    (p_yes, p_no, p_yes_size, p_no_size, ArbType::PolyOnly)
-                } else if arb_mask & 8 != 0 {
-                    (k_yes, k_no, k_yes_size, k_no_size, ArbType::KalshiOnly)
-                } else {
-                    continue;
-                };
-
-                let req = FastExecutionRequest {
-                    market_id: market.market_id,
-                    yes_price,
-                    no_price,
-                    yes_size,
-                    no_size,
-                    arb_type,
-                    detected_ns: sweep_clock.now_ns(),
-                    is_test: false,
-                };
-
                 if let Err(e) = sweep_exec_tx.try_send(req) {
                     let tui_active = sweep_tui_state.read().await.active;
                     log_line(format!("[SWEEP] Failed to send arb request: {}", e), tui_active);
@@ -1359,7 +1358,7 @@ async fn main() -> Result<()> {
     let heartbeat_tui_state = tui_state.clone();
     let heartbeat_log_tx = tui_log_tx.clone();
     let heartbeat_handle = tokio::spawn(async move {
-        use crate::types::kalshi_fee_cents;
+        use crate::arb::kalshi_fee;
         use std::collections::HashMap;
 
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
@@ -1447,9 +1446,9 @@ async fn main() -> Result<()> {
                     if verbose {
                         // Calculate gap and sizes only if both platforms have prices
                         let (gap, yes_size, no_size) = if has_k && has_p {
-                            let fee1 = kalshi_fee_cents(k_no);
+                            let fee1 = kalshi_fee(k_no);
                             let cost1 = p_yes + k_no + fee1;
-                            let fee2 = kalshi_fee_cents(k_yes);
+                            let fee2 = kalshi_fee(k_yes);
                             let cost2 = k_yes + fee2 + p_no;
                             // Determine which arb type is better and use those sizes
                             if cost1 <= cost2 {
@@ -1485,10 +1484,10 @@ async fn main() -> Result<()> {
                 if has_k && has_p {
                     with_both += 1;
 
-                    let fee1 = kalshi_fee_cents(k_no);
+                    let fee1 = kalshi_fee(k_no);
                     let cost1 = p_yes + k_no + fee1;
 
-                    let fee2 = kalshi_fee_cents(k_yes);
+                    let fee2 = kalshi_fee(k_yes);
                     let cost2 = k_yes + fee2 + p_no;
 
                     let (best_cost, best_fee, is_poly_yes, yes_size, no_size) = if cost1 <= cost2 {

--- a/controller/src/polymarket.rs
+++ b/controller/src/polymarket.rs
@@ -16,7 +16,7 @@ use tracing::{error, info, warn};
 use crate::config::{self, POLYMARKET_WS_URL, POLY_PING_INTERVAL_SECS, GAMMA_API_BASE, POLY_MAX_TOKENS_PER_WS};
 use crate::execution::NanoClock;
 use crate::types::{
-    GlobalState, FastExecutionRequest, ArbType, MarketPair, PriceCents, SizeCents,
+    GlobalState, ArbOpportunity, MarketPair, PriceCents, SizeCents,
     parse_price, fxhash_str,
 };
 
@@ -293,8 +293,8 @@ fn parse_size(s: &str) -> SizeCents {
 /// shutdown signal), all connections are aborted to trigger a coordinated reconnect.
 pub async fn run_ws(
     state: Arc<GlobalState>,
-    exec_tx: mpsc::Sender<FastExecutionRequest>,
-    confirm_tx: mpsc::Sender<(FastExecutionRequest, Arc<MarketPair>)>,
+    exec_tx: mpsc::Sender<ArbOpportunity>,
+    confirm_tx: mpsc::Sender<(ArbOpportunity, Arc<MarketPair>)>,
     threshold_cents: PriceCents,
     shutdown_rx: watch::Receiver<bool>,
     clock: Arc<NanoClock>,
@@ -421,8 +421,8 @@ async fn run_single_ws(
     conn_id: usize,
     tokens: Vec<String>,
     state: Arc<GlobalState>,
-    exec_tx: mpsc::Sender<FastExecutionRequest>,
-    confirm_tx: mpsc::Sender<(FastExecutionRequest, Arc<MarketPair>)>,
+    exec_tx: mpsc::Sender<ArbOpportunity>,
+    confirm_tx: mpsc::Sender<(ArbOpportunity, Arc<MarketPair>)>,
     threshold_cents: PriceCents,
     mut shutdown_rx: watch::Receiver<bool>,
     clock: Arc<NanoClock>,
@@ -585,9 +585,9 @@ async fn run_single_ws(
 async fn process_book(
     state: &GlobalState,
     book: &BookSnapshot,
-    exec_tx: &mpsc::Sender<FastExecutionRequest>,
-    confirm_tx: &mpsc::Sender<(FastExecutionRequest, Arc<MarketPair>)>,
-    threshold_cents: PriceCents,
+    exec_tx: &mpsc::Sender<ArbOpportunity>,
+    confirm_tx: &mpsc::Sender<(ArbOpportunity, Arc<MarketPair>)>,
+    _threshold_cents: PriceCents,
     clock: &NanoClock,
 ) {
     let token_hash = fxhash_str(&book.asset_id);
@@ -626,10 +626,15 @@ async fn process_book(
         market.mark_poly_update_unix_ms(now_ms);
         market.inc_poly_updates();
 
-        // Check arbs
-        let arb_mask = market.check_arbs(threshold_cents);
-        if arb_mask != 0 {
-            send_arb_request(state, market_id, market, arb_mask, exec_tx, confirm_tx, clock).await;
+        // Check arbs using ArbOpportunity::detect()
+        if let Some(req) = ArbOpportunity::detect(
+            market_id,
+            market.kalshi.load(),
+            market.poly.load(),
+            state.arb_config(),
+            clock.now_ns(),
+        ) {
+            route_arb_to_channel(state, market_id, req, exec_tx, confirm_tx).await;
         }
         matched = true;
     }
@@ -652,10 +657,15 @@ async fn process_book(
         market.mark_poly_update_unix_ms(now_ms);
         market.inc_poly_updates();
 
-        // Check arbs
-        let arb_mask = market.check_arbs(threshold_cents);
-        if arb_mask != 0 {
-            send_arb_request(state, market_id, market, arb_mask, exec_tx, confirm_tx, clock).await;
+        // Check arbs using ArbOpportunity::detect()
+        if let Some(req) = ArbOpportunity::detect(
+            market_id,
+            market.kalshi.load(),
+            market.poly.load(),
+            state.arb_config(),
+            clock.now_ns(),
+        ) {
+            route_arb_to_channel(state, market_id, req, exec_tx, confirm_tx).await;
         }
         matched = true;
     }
@@ -674,9 +684,9 @@ async fn process_book(
 async fn process_price_change(
     state: &GlobalState,
     change: &PriceChangeItem,
-    exec_tx: &mpsc::Sender<FastExecutionRequest>,
-    confirm_tx: &mpsc::Sender<(FastExecutionRequest, Arc<MarketPair>)>,
-    threshold_cents: PriceCents,
+    exec_tx: &mpsc::Sender<ArbOpportunity>,
+    confirm_tx: &mpsc::Sender<(ArbOpportunity, Arc<MarketPair>)>,
+    _threshold_cents: PriceCents,
     clock: &NanoClock,
 ) {
     // Only process SELL (ask) side updates
@@ -712,9 +722,14 @@ async fn process_price_change(
 
         // Only check arbs when price improves (lower = better for buying)
         if price < current_yes || current_yes == 0 {
-            let arb_mask = market.check_arbs(threshold_cents);
-            if arb_mask != 0 {
-                send_arb_request(state, market_id, market, arb_mask, exec_tx, confirm_tx, clock).await;
+            if let Some(req) = ArbOpportunity::detect(
+                market_id,
+                market.kalshi.load(),
+                market.poly.load(),
+                state.arb_config(),
+                clock.now_ns(),
+            ) {
+                route_arb_to_channel(state, market_id, req, exec_tx, confirm_tx).await;
             }
         }
     }
@@ -736,56 +751,30 @@ async fn process_price_change(
 
         // Only check arbs when price improves (lower = better for buying)
         if price < current_no || current_no == 0 {
-            let arb_mask = market.check_arbs(threshold_cents);
-            if arb_mask != 0 {
-                send_arb_request(state, market_id, market, arb_mask, exec_tx, confirm_tx, clock).await;
+            if let Some(req) = ArbOpportunity::detect(
+                market_id,
+                market.kalshi.load(),
+                market.poly.load(),
+                state.arb_config(),
+                clock.now_ns(),
+            ) {
+                route_arb_to_channel(state, market_id, req, exec_tx, confirm_tx).await;
             }
         }
     }
 }
 
-/// Send arb request to execution engine, routing to confirm channel if required
+/// Route a detected arbitrage opportunity to the appropriate channel.
+///
+/// Routes to confirm_tx if the league requires confirmation, otherwise to exec_tx.
 #[inline]
-async fn send_arb_request(
+async fn route_arb_to_channel(
     state: &GlobalState,
     market_id: u16,
-    market: &crate::types::AtomicMarketState,
-    arb_mask: u8,
-    exec_tx: &mpsc::Sender<FastExecutionRequest>,
-    confirm_tx: &mpsc::Sender<(FastExecutionRequest, Arc<MarketPair>)>,
-    clock: &NanoClock,
+    req: ArbOpportunity,
+    exec_tx: &mpsc::Sender<ArbOpportunity>,
+    confirm_tx: &mpsc::Sender<(ArbOpportunity, Arc<MarketPair>)>,
 ) {
-    let (k_yes, k_no, k_yes_size, k_no_size) = market.kalshi.load();
-    let (p_yes, p_no, p_yes_size, p_no_size) = market.poly.load();
-
-    // Priority order: cross-platform arbs first (more reliable)
-    let (yes_price, no_price, yes_size, no_size, arb_type) = if arb_mask & 1 != 0 {
-        // Poly YES + Kalshi NO
-        (p_yes, k_no, p_yes_size, k_no_size, ArbType::PolyYesKalshiNo)
-    } else if arb_mask & 2 != 0 {
-        // Kalshi YES + Poly NO
-        (k_yes, p_no, k_yes_size, p_no_size, ArbType::KalshiYesPolyNo)
-    } else if arb_mask & 4 != 0 {
-        // Poly only (both sides)
-        (p_yes, p_no, p_yes_size, p_no_size, ArbType::PolyOnly)
-    } else if arb_mask & 8 != 0 {
-        // Kalshi only (both sides)
-        (k_yes, k_no, k_yes_size, k_no_size, ArbType::KalshiOnly)
-    } else {
-        return;
-    };
-
-    let req = FastExecutionRequest {
-        market_id,
-        yes_price,
-        no_price,
-        yes_size,
-        no_size,
-        arb_type,
-        detected_ns: clock.now_ns(),
-        is_test: false,
-    };
-
     // Get market pair to check if confirmation is required
     let pair = match state.get_by_id(market_id).and_then(|m| m.pair()) {
         Some(p) => p,
@@ -845,7 +834,7 @@ mod tests {
     ///   - YES for Market 2 (Thieves winning)
     ///   - NO for Market 1 (OpTic losing)
     fn create_esports_state_with_shared_tokens() -> (GlobalState, String, String) {
-        let state = GlobalState::new();
+        let state = GlobalState::default();
 
         // Real token IDs from production logs (truncated for readability in tests)
         let token_optic = "43216923243873086858".to_string();  // OpTic Texas wins
@@ -1046,7 +1035,7 @@ mod tests {
         // With the bug, only YES matches were logged, NO matches never happened.
         // After fix, both YES and NO matches should occur for each book snapshot.
 
-        let state = GlobalState::new();
+        let state = GlobalState::default();
 
         // Exact token IDs from production
         let token_a = "43216923243873086858".to_string();
@@ -1126,7 +1115,7 @@ mod tests {
     fn test_standard_market_single_token_per_role() {
         // Standard sports markets (NBA, NFL, etc.) don't have shared tokens.
         // Each market has unique YES/NO tokens. Verify this still works.
-        let state = GlobalState::new();
+        let state = GlobalState::default();
 
         let pair = MarketPair {
             pair_id: "nba-lal-bos".into(),

--- a/controller/src/position_tracker.rs
+++ b/controller/src/position_tracker.rs
@@ -457,7 +457,13 @@ impl PositionChannel {
 
     #[inline]
     pub fn record_fill(&self, fill: FillRecord) {
-        let _ = self.tx.send(fill);
+        if let Err(e) = self.tx.send(fill) {
+            // This is critical - losing fills means incorrect P&L and audit trail
+            tracing::error!(
+                "[POSITION] Failed to record fill - DATA LOSS! Fill: {:?}, Error: {}",
+                e.0, e
+            );
+        }
     }
 }
 

--- a/controller/src/remote_execution.rs
+++ b/controller/src/remote_execution.rs
@@ -14,7 +14,7 @@ use crate::config::{KALSHI_WEB_BASE, build_polymarket_url};
 use crate::execution::describe_arb_trade;
 use crate::remote_protocol::{IncomingMessage, OrderAction, OutcomeSide, Platform as WsPlatform};
 use crate::remote_trader::RemoteTraderRouter;
-use crate::types::{ArbType, FastExecutionRequest, GlobalState, MarketPair};
+use crate::types::{ArbType, ArbOpportunity, GlobalState, MarketPair};
 
 use trading::execution::{
     execute_leg, ExecutionClients, LegRequest, OrderAction as TradingOrderAction,
@@ -71,11 +71,15 @@ impl HybridExecutor {
         }
     }
 
-    /// Log a message - sends to TUI channel if available, otherwise uses tracing
+    /// Log a message - sends to TUI channel if available, otherwise uses tracing.
+    /// Falls back to tracing if TUI channel is full or closed.
     fn log_info(&self, msg: String) {
         let formatted = format!("[{}]  INFO {}", Local::now().format("%H:%M:%S"), msg);
         if let Some(tx) = &self.log_tx {
-            let _ = tx.try_send(formatted);
+            if tx.try_send(formatted).is_err() {
+                // Channel full or closed, fallback to tracing
+                info!("{}", msg);
+            }
         } else {
             info!("{}", msg);
         }
@@ -84,7 +88,9 @@ impl HybridExecutor {
     fn log_warn(&self, msg: String) {
         let formatted = format!("[{}]  WARN {}", Local::now().format("%H:%M:%S"), msg);
         if let Some(tx) = &self.log_tx {
-            let _ = tx.try_send(formatted);
+            if tx.try_send(formatted).is_err() {
+                warn!("{}", msg);
+            }
         } else {
             warn!("{}", msg);
         }
@@ -93,7 +99,9 @@ impl HybridExecutor {
     fn log_error(&self, msg: String) {
         let formatted = format!("[{}] ERROR {}", Local::now().format("%H:%M:%S"), msg);
         if let Some(tx) = &self.log_tx {
-            let _ = tx.try_send(formatted);
+            if tx.try_send(formatted).is_err() {
+                error!("{}", msg);
+            }
         } else {
             error!("{}", msg);
         }
@@ -112,7 +120,7 @@ impl HybridExecutor {
         }
     }
 
-    pub async fn process(&self, req: FastExecutionRequest) -> Result<()> {
+    pub async fn process(&self, req: ArbOpportunity) -> Result<()> {
         let market_id = req.market_id;
 
         // Deduplication check (512 markets via 8x u64 bitmask)
@@ -325,7 +333,7 @@ impl HybridExecutor {
 }
 
 fn build_legs(
-    req: &FastExecutionRequest,
+    req: &ArbOpportunity,
     pair: &MarketPair,
     contracts: i64,
     leg_seq: &AtomicU64,
@@ -487,7 +495,7 @@ fn build_legs(
 
 /// Hybrid execution event loop - forwards arbitrage opportunities to remote traders or executes locally.
 pub async fn run_hybrid_execution_loop(
-    mut rx: mpsc::Receiver<FastExecutionRequest>,
+    mut rx: mpsc::Receiver<ArbOpportunity>,
     executor: Arc<HybridExecutor>,
 ) {
     executor.log_info(format!(
@@ -543,7 +551,7 @@ mod tests {
     }
 
     fn make_state_with_pair(pair: MarketPair) -> Arc<GlobalState> {
-        let state = Arc::new(GlobalState::new());
+        let state = Arc::new(GlobalState::default());
         let id = state.add_pair(pair).expect("add_pair");
         assert_eq!(id, 0);
         state
@@ -562,7 +570,7 @@ mod tests {
         // No polymarket trader connected and no local authorization
 
         let exec = HybridExecutor::new(state, cb, router, HashSet::new(), None, None, true, None);
-        let req = FastExecutionRequest {
+        let req = ArbOpportunity {
             market_id: 0,
             yes_price: 40,
             no_price: 50,
@@ -590,7 +598,7 @@ mod tests {
         let mut poly_rx = router.test_register(WsPlatform::Polymarket).await;
 
         let exec = HybridExecutor::new(state, cb, router, HashSet::new(), None, None, true, None);
-        let req = FastExecutionRequest {
+        let req = ArbOpportunity {
             market_id: 0,
             yes_price: 40,
             no_price: 50,
@@ -636,7 +644,7 @@ mod tests {
         let mut poly_rx = router.test_register(WsPlatform::Polymarket).await;
 
         let exec = HybridExecutor::new(state, cb, router, HashSet::new(), None, None, true, None);
-        let req = FastExecutionRequest {
+        let req = ArbOpportunity {
             market_id: 0,
             yes_price: 48,
             no_price: 50,

--- a/controller/tests/integration/test_execution_engine.rs
+++ b/controller/tests/integration/test_execution_engine.rs
@@ -40,7 +40,7 @@ use arb_bot::kalshi::{KalshiApiClient, KalshiConfig};
 use arb_bot::poly_executor::mock::MockPolyClient;
 use arb_bot::poly_executor::PolyExecutor;
 use arb_bot::position_tracker::{create_position_channel, FillRecord};
-use arb_bot::types::{ArbType, FastExecutionRequest, GlobalState, MarketPair, MarketType};
+use arb_bot::types::{ArbType, ArbOpportunity, GlobalState, MarketPair, MarketType};
 
 use super::replay_harness::load_fixture;
 
@@ -112,7 +112,7 @@ fn create_test_engine(
     mock_poly: Arc<dyn PolyExecutor>,
 ) -> (ExecutionEngine, mpsc::UnboundedReceiver<FillRecord>) {
     let kalshi = Arc::new(create_test_kalshi_client(kalshi_server));
-    let state = Arc::new(GlobalState::new());
+    let state = Arc::new(GlobalState::default());
     let circuit_breaker = Arc::new(create_disabled_circuit_breaker());
     let (position_channel, fill_rx) = create_position_channel();
     let clock = Arc::new(NanoClock::new());
@@ -134,9 +134,9 @@ fn create_test_engine(
     (engine, fill_rx)
 }
 
-/// Create a FastExecutionRequest for testing.
-fn create_test_request(arb_type: ArbType) -> FastExecutionRequest {
-    FastExecutionRequest {
+/// Create a ArbOpportunity for testing.
+fn create_test_request(arb_type: ArbType) -> ArbOpportunity {
+    ArbOpportunity {
         market_id: 0,
         yes_price: 9,   // 9 cents
         no_price: 85,   // 85 cents

--- a/docs/plans/2026-01-22-arb-type-consolidation.md
+++ b/docs/plans/2026-01-22-arb-type-consolidation.md
@@ -1,0 +1,672 @@
+# Arb Type Consolidation: Merge ArbOpportunity into FastExecutionRequest
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Date:** 2026-01-22
+**Status:** Draft
+**Goal:** Eliminate type duplication by consolidating `ArbOpportunity` and `FastExecutionRequest` into a single type, then rename to `ArbOpportunity`.
+
+**Tech Stack:** Rust, no new dependencies
+
+---
+
+## Background
+
+### Current State
+
+Two types exist for representing arbitrage opportunities:
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `ArbOpportunity` | `arb.rs` | Detection/validation phase |
+| `FastExecutionRequest` | `types.rs` | Execution phase |
+
+### The Problem
+
+These types are nearly identical:
+
+```rust
+// ArbOpportunity (arb.rs)
+struct ArbOpportunity {
+    market_id: u16,
+    arb_type: Option<ArbType>,  // None = invalid
+    yes_price: u16,
+    no_price: u16,
+    yes_size: u16,
+    no_size: u16,
+    detected_ns: u64,
+}
+
+// FastExecutionRequest (types.rs)
+struct FastExecutionRequest {
+    market_id: u16,
+    arb_type: ArbType,          // Always present
+    yes_price: u16,
+    no_price: u16,
+    yes_size: u16,
+    no_size: u16,
+    detected_ns: u64,
+    is_test: bool,              // Only difference
+}
+```
+
+**Duplicated calculations across the codebase:**
+
+| Calculation | Locations |
+|-------------|-----------|
+| `max_contracts()` | `ArbOpportunity::max_contracts()`, `PendingArb::max_contracts()`, `ExecutionEngine::process()` |
+| `profit_cents()` | `ArbOpportunity::gross_profit_cents()`, `FastExecutionRequest::profit_cents()` |
+| fee calculation | `arb::kalshi_fee()`, `confirm_queue.rs::validate_arb_detailed()` |
+
+### Design Flaw
+
+The two-type design was intended to provide type safety:
+- `ArbOpportunity` with `Option<ArbType>` represents "maybe an arb"
+- `FastExecutionRequest` with `ArbType` represents "definitely an arb"
+
+But this doesn't provide meaningful safety because:
+1. Invalid arbs (`arb_type = None`) are never stored or passed
+2. `FastExecutionRequest::from_arb()` panics if called on invalid arbs
+3. The `Option<FastExecutionRequest>` return from a factory provides the same semantic
+
+### Target State
+
+A single type with a factory function that returns `Option<Self>`:
+
+```rust
+impl ArbOpportunity {
+    /// Detect arb from orderbook data. Returns None if no valid arb.
+    pub fn detect(
+        market_id: u16,
+        kalshi: (u16, u16, u16, u16),
+        poly: (u16, u16, u16, u16),
+        config: &ArbConfig,
+        detected_ns: u64,
+    ) -> Option<Self> { ... }
+}
+```
+
+---
+
+## Task 1: Add `detect()` factory to FastExecutionRequest
+
+**Files:**
+- Modify: `controller/src/types.rs`
+
+**Step 1: Write the failing test**
+
+Add to `controller/src/types.rs` tests:
+
+```rust
+#[cfg(test)]
+mod arb_detection_tests {
+    use super::*;
+    use crate::arb::ArbConfig;
+
+    #[test]
+    fn test_detect_returns_none_when_prices_too_high() {
+        let config = ArbConfig::default();
+
+        // Prices sum to 100 cents = no profit
+        let result = FastExecutionRequest::detect(
+            1,                          // market_id
+            (50, 50, 1000, 1000),       // kalshi
+            (50, 50, 1000, 1000),       // poly
+            &config,
+            12345,
+        );
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_finds_poly_yes_kalshi_no() {
+        let config = ArbConfig::default(); // threshold = 99
+
+        // Poly YES @ 45 + Kalshi NO @ 52 = 97 cents (+ ~1c fee) = ~98 < 99
+        let result = FastExecutionRequest::detect(
+            1,
+            (55, 52, 500, 500),        // kalshi
+            (45, 58, 500, 500),        // poly
+            &config,
+            12345,
+        );
+
+        let arb = result.expect("should detect arb");
+        assert_eq!(arb.arb_type, ArbType::PolyYesKalshiNo);
+        assert_eq!(arb.yes_price, 45);  // poly yes
+        assert_eq!(arb.no_price, 52);   // kalshi no
+    }
+
+    #[test]
+    fn test_detect_returns_none_when_size_insufficient() {
+        let config = ArbConfig::default();
+
+        // Great prices but no size on kalshi NO side
+        let result = FastExecutionRequest::detect(
+            1,
+            (55, 52, 500, 0),          // kalshi: no_size = 0
+            (45, 58, 500, 500),
+            &config,
+            12345,
+        );
+
+        assert!(result.is_none());
+    }
+}
+```
+
+**Step 2: Implement `detect()` by moving logic from ArbOpportunity::new()**
+
+```rust
+impl FastExecutionRequest {
+    /// Detect arbitrage opportunity from orderbook data.
+    /// Returns Some if a valid arb exists, None otherwise.
+    ///
+    /// This is the single source of truth for arb detection logic.
+    pub fn detect(
+        market_id: u16,
+        kalshi: (PriceCents, PriceCents, SizeCents, SizeCents),
+        poly: (PriceCents, PriceCents, SizeCents, SizeCents),
+        config: &crate::arb::ArbConfig,
+        detected_ns: u64,
+    ) -> Option<Self> {
+        use crate::arb::kalshi_fee;
+
+        let (k_yes, k_no, k_yes_size, k_no_size) = kalshi;
+        let (p_yes, p_no, p_yes_size, p_no_size) = poly;
+
+        // Check for invalid prices (0 = no price available)
+        if k_yes == 0 || k_no == 0 || p_yes == 0 || p_no == 0 {
+            return None;
+        }
+
+        // Calculate Kalshi fees
+        let k_yes_fee = kalshi_fee(k_yes);
+        let k_no_fee = kalshi_fee(k_no);
+
+        // Arb candidates in priority order
+        let candidates = [
+            (ArbType::PolyYesKalshiNo, p_yes + k_no + k_no_fee, p_yes, k_no, p_yes_size, k_no_size),
+            (ArbType::KalshiYesPolyNo, k_yes + k_yes_fee + p_no, k_yes, p_no, k_yes_size, p_no_size),
+            (ArbType::PolyOnly, p_yes + p_no, p_yes, p_no, p_yes_size, p_no_size),
+            (ArbType::KalshiOnly, k_yes + k_yes_fee + k_no + k_no_fee, k_yes, k_no, k_yes_size, k_no_size),
+        ];
+
+        // Find first valid arb (lowest cost that beats threshold)
+        for (arb_type, cost, yes_price, no_price, yes_size, no_size) in candidates {
+            if cost <= config.threshold_cents {
+                let max_contracts = (yes_size.min(no_size) as f64) / 100.0;
+
+                if max_contracts >= config.min_contracts {
+                    return Some(Self {
+                        market_id,
+                        arb_type,
+                        yes_price,
+                        no_price,
+                        yes_size,
+                        no_size,
+                        detected_ns,
+                        is_test: false,
+                    });
+                }
+            }
+        }
+
+        None
+    }
+}
+```
+
+**Step 3: Run tests**
+
+```bash
+cargo test -p controller arb_detection_tests
+```
+
+**Step 4: Commit**
+
+```bash
+git add controller/src/types.rs
+git commit -m "$(cat <<'EOF'
+feat(types): add detect() factory to FastExecutionRequest
+
+Move arb detection logic into FastExecutionRequest::detect().
+Returns Option<Self> - None if no valid arb, Some if valid.
+This is preparation for eliminating the duplicate ArbOpportunity type.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add missing methods to FastExecutionRequest
+
+**Files:**
+- Modify: `controller/src/types.rs`
+
+Ensure `FastExecutionRequest` has all methods currently on `ArbOpportunity`:
+
+**Step 1: Add max_contracts() if not present**
+
+```rust
+impl FastExecutionRequest {
+    /// Calculate max executable contracts (minimum of both sides)
+    #[inline]
+    pub fn max_contracts(&self) -> u16 {
+        if self.yes_price == 0 || self.no_price == 0 {
+            return 0;
+        }
+        let yes_contracts = self.yes_size / self.yes_price;
+        let no_contracts = self.no_size / self.no_price;
+        yes_contracts.min(no_contracts)
+    }
+}
+```
+
+**Step 2: Verify profit_cents() exists and matches**
+
+The method should match `ArbOpportunity::gross_profit_cents()` logic.
+
+**Step 3: Commit**
+
+```bash
+git add controller/src/types.rs
+git commit -m "$(cat <<'EOF'
+feat(types): add max_contracts() to FastExecutionRequest
+
+Consolidate contract calculation into single location.
+Previously duplicated in ArbOpportunity, PendingArb, and ExecutionEngine.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Migrate callers from ArbOpportunity::new() to FastExecutionRequest::detect()
+
+**Files:**
+- Modify: `controller/src/kalshi.rs`
+- Modify: `controller/src/polymarket.rs`
+- Modify: `controller/src/main.rs`
+- Modify: `controller/src/confirm_queue.rs`
+
+**Step 1: Update kalshi.rs**
+
+Before:
+```rust
+let arb = ArbOpportunity::new(market_id, kalshi, poly, config, ts);
+if arb.is_valid() {
+    let request = FastExecutionRequest::from_arb(&arb);
+    // send request
+}
+```
+
+After:
+```rust
+if let Some(request) = FastExecutionRequest::detect(market_id, kalshi, poly, config, ts) {
+    // send request directly
+}
+```
+
+**Step 2: Update polymarket.rs**
+
+Same pattern as kalshi.rs.
+
+**Step 3: Update main.rs (startup sweep, heartbeat)**
+
+Same pattern.
+
+**Step 4: Update confirm_queue.rs validate_arb()**
+
+Before:
+```rust
+pub fn validate_arb(&self, arb: &PendingArb, config: &ArbConfig) -> Option<ArbOpportunity> {
+    let opp = ArbOpportunity::new(...);
+    if opp.is_valid() { Some(opp) } else { None }
+}
+```
+
+After:
+```rust
+pub fn validate_arb(&self, arb: &PendingArb, config: &ArbConfig) -> Option<FastExecutionRequest> {
+    FastExecutionRequest::detect(...)
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cargo test -p controller
+cargo check -p controller
+```
+
+**Step 6: Commit**
+
+```bash
+git add controller/src/kalshi.rs controller/src/polymarket.rs controller/src/main.rs controller/src/confirm_queue.rs
+git commit -m "$(cat <<'EOF'
+refactor: migrate from ArbOpportunity::new() to FastExecutionRequest::detect()
+
+All arb detection now uses FastExecutionRequest::detect() which returns
+Option<Self>. This eliminates the intermediate ArbOpportunity type and
+removes the from_arb() conversion step.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update PendingArb to delegate to FastExecutionRequest
+
+**Files:**
+- Modify: `controller/src/confirm_queue.rs`
+
+**Step 1: Remove duplicate max_contracts()**
+
+Before:
+```rust
+impl PendingArb {
+    pub fn max_contracts(&self) -> i64 {
+        if self.request.yes_price == 0 || self.request.no_price == 0 {
+            return 0;
+        }
+        let yes_contracts = self.request.yes_size / self.request.yes_price;
+        let no_contracts = self.request.no_size / self.request.no_price;
+        yes_contracts.min(no_contracts) as i64
+    }
+}
+```
+
+After:
+```rust
+impl PendingArb {
+    pub fn max_contracts(&self) -> u16 {
+        self.request.max_contracts()
+    }
+}
+```
+
+**Step 2: Verify profit_cents() delegates**
+
+```rust
+impl PendingArb {
+    pub fn profit_cents(&self) -> i16 {
+        self.request.profit_cents()
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add controller/src/confirm_queue.rs
+git commit -m "$(cat <<'EOF'
+refactor(confirm): delegate calculations to FastExecutionRequest
+
+PendingArb.max_contracts() and profit_cents() now delegate to
+FastExecutionRequest methods, eliminating duplicate calculation logic.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Remove from_arb() from FastExecutionRequest
+
+**Files:**
+- Modify: `controller/src/types.rs`
+
+**Step 1: Verify no remaining callers**
+
+```bash
+grep -r "from_arb" controller/src/
+```
+
+Expected: Only the definition, no callers.
+
+**Step 2: Delete the method**
+
+Remove:
+```rust
+pub fn from_arb(arb: &crate::arb::ArbOpportunity) -> Self { ... }
+```
+
+**Step 3: Commit**
+
+```bash
+git add controller/src/types.rs
+git commit -m "$(cat <<'EOF'
+refactor(types): remove from_arb() conversion method
+
+No longer needed since callers use detect() directly.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Delete ArbOpportunity struct
+
+**Files:**
+- Modify: `controller/src/arb.rs`
+
+**Step 1: Verify no remaining references**
+
+```bash
+grep -r "ArbOpportunity" controller/src/
+```
+
+Expected: Only the definition in arb.rs and possibly tests.
+
+**Step 2: Delete the struct and its impl block**
+
+Keep in `arb.rs`:
+- `ArbConfig` struct and impl
+- `kalshi_fee()` function
+- Tests for `ArbConfig` and `kalshi_fee()`
+
+Delete:
+- `ArbOpportunity` struct
+- All `ArbOpportunity` methods
+- `ArbOpportunity` tests
+
+**Step 3: Update arb.rs module doc**
+
+```rust
+//! Centralized arbitrage configuration and fee calculation.
+//!
+//! Arb detection logic lives in `FastExecutionRequest::detect()`.
+//! This module provides:
+//! - `ArbConfig` - threshold and min_contracts configuration
+//! - `kalshi_fee()` - Kalshi fee calculation
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p controller
+cargo check -p controller
+```
+
+**Step 5: Commit**
+
+```bash
+git add controller/src/arb.rs
+git commit -m "$(cat <<'EOF'
+refactor(arb): delete ArbOpportunity struct
+
+Detection logic now lives in FastExecutionRequest::detect().
+arb.rs retains ArbConfig and kalshi_fee() for configuration and fees.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Rename FastExecutionRequest to ArbOpportunity
+
+**Files:**
+- Modify: `controller/src/types.rs`
+- Modify: All files that reference `FastExecutionRequest`
+
+**Step 1: Rename the struct**
+
+In `types.rs`:
+```rust
+// Before
+pub struct FastExecutionRequest { ... }
+
+// After
+pub struct ArbOpportunity { ... }
+```
+
+**Step 2: Add type alias for gradual migration (optional)**
+
+```rust
+/// Deprecated: Use ArbOpportunity instead
+#[deprecated(note = "Renamed to ArbOpportunity")]
+pub type FastExecutionRequest = ArbOpportunity;
+```
+
+**Step 3: Update all references**
+
+Files to update:
+- `controller/src/types.rs` - definition and impls
+- `controller/src/kalshi.rs` - channel types, function signatures
+- `controller/src/polymarket.rs` - channel types, function signatures
+- `controller/src/main.rs` - channel creation, function calls
+- `controller/src/execution.rs` - process() signature
+- `controller/src/confirm_queue.rs` - PendingArb.request type
+- `controller/src/remote_execution.rs` - serialization
+- Test files
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p controller
+cargo check -p controller
+```
+
+**Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+refactor: rename FastExecutionRequest to ArbOpportunity
+
+Single type now represents a validated arbitrage opportunity.
+- detect() factory returns Option<ArbOpportunity>
+- Contains all arb data: market_id, prices, sizes, arb_type
+- Provides max_contracts() and profit_cents() calculations
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Remove deprecated type alias
+
+**Files:**
+- Modify: `controller/src/types.rs`
+
+**Step 1: Verify no remaining FastExecutionRequest references**
+
+```bash
+grep -r "FastExecutionRequest" controller/
+```
+
+**Step 2: Remove the type alias**
+
+Delete:
+```rust
+#[deprecated(note = "Renamed to ArbOpportunity")]
+pub type FastExecutionRequest = ArbOpportunity;
+```
+
+**Step 3: Commit**
+
+```bash
+git add controller/src/types.rs
+git commit -m "$(cat <<'EOF'
+chore: remove deprecated FastExecutionRequest type alias
+
+All code now uses ArbOpportunity directly.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Update documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Delete: `docs/plans/2026-01-21-arb-opportunity-refactor.md` (superseded)
+
+**Step 1: Update CLAUDE.md architecture section**
+
+Update the data flow diagram:
+```
+WebSocket Price Updates (kalshi.rs, polymarket.rs)
+    ↓
+Global State with Lock-Free Orderbook Cache (types.rs)
+    ↓
+ArbOpportunity::detect() in WebSocket Handlers
+    ↓
+Confirmation Queue (confirm_queue.rs) or Direct Execution
+    ↓
+...
+```
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git rm docs/plans/2026-01-21-arb-opportunity-refactor.md
+git commit -m "$(cat <<'EOF'
+docs: update architecture for ArbOpportunity consolidation
+
+- Update CLAUDE.md data flow to show ArbOpportunity::detect()
+- Remove superseded refactor plan
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Summary
+
+After completing all tasks:
+
+| Before | After |
+|--------|-------|
+| `ArbOpportunity` + `FastExecutionRequest` | Single `ArbOpportunity` type |
+| `ArbOpportunity::new()` + `from_arb()` | `ArbOpportunity::detect() -> Option<Self>` |
+| `max_contracts()` in 4 places | Single method on `ArbOpportunity` |
+| `profit_cents()` in 3 places | Single method on `ArbOpportunity` |
+| 2 structs with 7 duplicate fields | 1 struct, no duplication |
+
+**Benefits:**
+1. Single source of truth for arb representation
+2. No duplicate calculations
+3. Cleaner API: `detect()` returns `Option<Self>` instead of requiring validity check
+4. Better name: `ArbOpportunity` is more descriptive than `FastExecutionRequest`

--- a/env.example
+++ b/env.example
@@ -62,6 +62,20 @@ RUST_LOG=info
 # HEARTBEAT_INTERVAL_SECS=10
 
 # ============================================
+# ARBITRAGE DETECTION
+# ============================================
+
+# Threshold in cents for profitable arb (default: 99)
+# An arb is valid when total cost (prices + fees) <= threshold
+# Valid range: 1-100. Lower = more conservative (fewer arbs)
+# ARB_THRESHOLD_CENTS=99
+
+# Minimum contracts for a valid arb (default: 1.0)
+# Arbs with fewer executable contracts are rejected
+# Must be > 0
+# ARB_MIN_CONTRACTS=1.0
+
+# ============================================
 # CIRCUIT BREAKER (Risk Management)
 # ============================================
 


### PR DESCRIPTION
## Summary

This PR brings the `ArbOpportunity` refactor from `refactor/arb-opp` into main. The original refactor was accidentally merged into `bugfix/tui-logging` instead of main (PR #23 used the wrong base branch).

**Key changes:**
- Rename `FastExecutionRequest` to `ArbOpportunity` across codebase
- Add `arb.rs` module with centralized arb config (`ArbConfig`) and fee calculation (`kalshi_fee`)
- Add `ArbOpportunity::detect()` factory for validating arb opportunities with current orderbook prices
- Add `max_contracts()` method to calculate executable contracts based on size and price
- Add unit tests for `PendingArb` calculations in `confirm_queue.rs`
- Update `env.example` with `ARB_THRESHOLD_CENTS` and `ARB_MIN_CONTRACTS`

**Conflict resolutions:**
- `CLAUDE.md`: Keep detailed documentation table from main
- `confirm_queue.rs`: Keep timestamp fields (`first_detected`, `last_detected`), add tests from refactor
- `execution.rs`: Keep error logging to tracing for persistence/Sentry
- `kalshi.rs`: Keep `warn!()` macro for consistency with rest of codebase
- `main.rs`: Keep timestamp formatting for TUI logs, improved error handling with dropped count

## Test plan

- [x] `cargo build --release` succeeds
- [x] `cargo test -p controller --lib -- --test-threads=1` passes (21 arb-related tests)
- [ ] Manual testing with `TEST_ARB=1` synthetic arb injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)