### PR TITLE
feat: add --kalshi-ticker flag for single-event mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ FORCE_DISCOVERY=1 dotenvx run -- cargo run --release
 
 # Test mode with synthetic arbitrage
 TEST_ARB=1 TEST_ARB_TYPE=poly_yes_kalshi_no dotenvx run -- cargo run --release
+
+# Single-event mode (monitor only one Kalshi event)
+dotenvx run -- cargo run --release -- --kalshi-ticker KXNBAGAME-26JAN24MIAUTA
 ```
 
 ## Architecture Overview

--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ DRY_RUN=0 CONTROLLER_PLATFORMS=kalshi,polymarket cargo run -p controller --relea
 DRY_RUN=0 CONTROLLER_PLATFORMS=kalshi cargo run -p controller --release
 ```
 
+### Single-Event Mode
+
+Monitor only a specific Kalshi event (useful for debugging or focused monitoring):
+
+```bash
+# Monitor a single NBA game
+cargo run -p controller --release -- --kalshi-ticker KXNBAGAME-26JAN24MIAUTA
+
+# With dry run
+DRY_RUN=1 cargo run -p controller --release -- --kalshi-ticker KXNBAGAME-26JAN24MIAUTA
+```
+
+This fetches all markets under the specified event ticker and matches them to Polymarket, bypassing normal discovery.
+
 ### Quick Smoke Test
 
 ```bash
@@ -223,6 +237,13 @@ See `trader/README.md` for setup and required environment variables.
 | `FORCE_DISCOVERY` | `false` | `1` or `true` = clear cache and re-fetch all markets |
 | `DISCOVERY_INTERVAL_MINS` | `15` | Minutes between discovery refreshes (0 = disabled) |
 | `ENABLED_LEAGUES` | *(all)* | Comma-separated leagues to monitor (see below) |
+
+**CLI flags:**
+| Flag | Description |
+|------|-------------|
+| `--leagues nba,nfl` | Override `ENABLED_LEAGUES` from command line |
+| `--market-type moneyline` | Filter to specific market type (`moneyline`, `spread`, `total`, `btts`) |
+| `--kalshi-ticker TICKER` | Single-event mode: monitor only markets under this Kalshi event ticker |
 
 **Supported leagues**: `epl`, `bundesliga`, `laliga`, `seriea`, `ligue1`, `ucl`, `uel`, `eflc`, `nba`, `nfl`, `nhl`, `mlb`, `mls`, `ncaaf`, `cs2`, `lol`, `cod`
 


### PR DESCRIPTION
## Summary

- Add `--kalshi-ticker` CLI flag to monitor only a specific Kalshi event
- Bypasses normal discovery for focused debugging or monitoring of individual games
- Fetches all markets under the specified event and matches them to Polymarket

## Usage

```bash
# Monitor a single NBA game
cargo run -p controller -- --kalshi-ticker KXNBAGAME-26JAN24MIAUTA

# With dry run
DRY_RUN=1 cargo run -p controller --release -- --kalshi-ticker KXNBAGAME-26JAN24MIAUTA
```

## Test plan

- [x] Code compiles without errors
- [x] Test with valid event ticker (e.g., `KXNBAGAME-26JAN24MIAUTA`)
- [x] Verify markets are discovered and matched to Polymarket
- [x] Verify WebSocket subscriptions only include the targeted markets

🤖 Generated with [Claude Code](https://claude.com/claude-code)