### PR TITLE
fix: add debug logging for Polymarket fill parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ positions.json
 
 # Confirmation logs
 .confirmations/
+*.code-workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ When one leg of an arbitrage fills but the other fails (creating unhedged exposu
 **Required credentials:**
 - `KALSHI_API_KEY_ID`, `KALSHI_PRIVATE_KEY_PATH` (PEM file)
 - `POLY_PRIVATE_KEY` (0x-prefixed), `POLY_FUNDER` (wallet address)
+- `POLY_SIGNATURE_TYPE` (default: 0) - Signature type for Polymarket orders: 0=EOA direct signing, 1=Poly proxy, 2=Gnosis Safe
 
 **Execution:** `DRY_RUN` (default: 1), `RUST_LOG` (default: info)
 

--- a/controller/src/polymarket_clob.rs
+++ b/controller/src/polymarket_clob.rs
@@ -657,25 +657,49 @@ impl SharedAsyncClient {
         // For BUY: takingAmount = shares received, makingAmount = USDC spent
         // For SELL: takingAmount = USDC received, makingAmount = shares sold
         let (filled_size, fill_cost) = if side.eq_ignore_ascii_case("BUY") {
-            let shares: f64 = resp_json["takingAmount"]
-                .as_str()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0.0);
-            let cost: f64 = resp_json["makingAmount"]
-                .as_str()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0.0);
+            let shares: f64 = match resp_json["takingAmount"].as_str() {
+                Some(s) => s.parse().unwrap_or_else(|e| {
+                    tracing::warn!("[POLY] Failed to parse takingAmount '{}': {}", s, e);
+                    0.0
+                }),
+                None => {
+                    tracing::warn!("[POLY] takingAmount not present in response: {}", resp_json);
+                    0.0
+                }
+            };
+            let cost: f64 = match resp_json["makingAmount"].as_str() {
+                Some(s) => s.parse().unwrap_or_else(|e| {
+                    tracing::warn!("[POLY] Failed to parse makingAmount '{}': {}", s, e);
+                    0.0
+                }),
+                None => {
+                    tracing::warn!("[POLY] makingAmount not present in response: {}", resp_json);
+                    0.0
+                }
+            };
             (shares, cost)
         } else {
             // SELL: makingAmount is shares sold, takingAmount is USDC received
-            let shares: f64 = resp_json["makingAmount"]
-                .as_str()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0.0);
-            let cost: f64 = resp_json["takingAmount"]
-                .as_str()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0.0);
+            let shares: f64 = match resp_json["makingAmount"].as_str() {
+                Some(s) => s.parse().unwrap_or_else(|e| {
+                    tracing::warn!("[POLY] Failed to parse makingAmount '{}': {}", s, e);
+                    0.0
+                }),
+                None => {
+                    tracing::warn!("[POLY] makingAmount not present in response: {}", resp_json);
+                    0.0
+                }
+            };
+            let cost: f64 = match resp_json["takingAmount"].as_str() {
+                Some(s) => s.parse().unwrap_or_else(|e| {
+                    tracing::warn!("[POLY] Failed to parse takingAmount '{}': {}", s, e);
+                    0.0
+                }),
+                None => {
+                    tracing::warn!("[POLY] takingAmount not present in response: {}", resp_json);
+                    0.0
+                }
+            };
             (shares, cost)
         };
 


### PR DESCRIPTION
## Summary
- Add detailed warnings when `takingAmount`/`makingAmount` fields are missing or fail to parse from Polymarket responses
- Document `POLY_SIGNATURE_TYPE` env var in CLAUDE.md
- Add `*.code-workspace` to .gitignore

## Test plan
- [x] Existing tests pass
- [ ] Monitor logs during live trading to verify warnings appear when parsing issues occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)