### PR TITLE
fix: correct max_contracts calculation and add Polymarket $1 minimum validation

### DIFF
--- a/controller/src/remote_execution.rs
+++ b/controller/src/remote_execution.rs
@@ -148,7 +148,7 @@ impl HybridExecutor {
             return Ok(());
         }
 
-        let mut max_contracts = (req.yes_size.min(req.no_size) / 100) as i64;
+        let mut max_contracts = req.max_contracts() as i64;
         if max_contracts < 1 {
             self.release_in_flight_delayed(market_id);
             return Ok(());

--- a/controller/tests/hybrid_executor_tests.rs
+++ b/controller/tests/hybrid_executor_tests.rs
@@ -546,13 +546,14 @@ async fn test_hybrid_executor_drops_insufficient_size_arb() {
         None,
     );
 
-    // Size too small for even 1 contract (need >= 100 cents)
+    // Size too small for even 1 contract
+    // max_contracts = min(yes_size/yes_price, no_size/no_price) = min(39/40, 49/50) = min(0, 0) = 0
     let req = ArbOpportunity {
         market_id: 0,
         yes_price: 40,
         no_price: 50,
-        yes_size: 50,  // Less than 100 cents = 0 contracts
-        no_size: 50,
+        yes_size: 39,  // 39/40 = 0 contracts
+        no_size: 49,   // 49/50 = 0 contracts
         arb_type: ArbType::PolyYesKalshiNo,
         detected_ns: 0,
         is_test: false,


### PR DESCRIPTION
## Summary

- **Root cause fix**: `execution.rs` was using `min(yes_size, no_size) / 100` to calculate max_contracts, but `ArbOpportunity` uses `min(yes_size/yes_price, no_size/no_price)`. This caused orders with insufficient value to be sent to Polymarket.
- **Added validation**: Polymarket requires $1 minimum order value. Now validated in `ArbOpportunity::detect()` as single source of truth.
- **Safety net**: Post-circuit-breaker check in `execution.rs` handles cases where CB reduces contracts below $1 minimum.

## Bug Details

Captured request showed the exact failure:
```json
{
  "makerAmount": "490000",   // $0.49 (what we pay)
  "takerAmount": "1000000",  // 1.0 contracts
  "error": "invalid amount for a marketable BUY order ($0.49), min size: $1"
}
```

**Old (buggy) calculation:**
```rust
max_contracts = min(yes_size, no_size) / 100  // 147 / 100 = 1 contract
```

**New (correct) calculation:**
```rust
max_contracts = min(yes_size/yes_price, no_size/no_price)  // 147/49 = 3 contracts
```

## Test Coverage

| Arb Type | Test Scenario | Result |
|----------|--------------|--------|
| PolyYesKalshiNo | 1×49¢ = $0.49 | Rejected ✓ |
| PolyYesKalshiNo | 3×49¢ = $1.47 | Accepted ✓ |
| KalshiYesPolyNo | Poly NO validation | Covered ✓ |
| PolyOnly | Both legs must be ≥$1 | Covered ✓ |
| KalshiOnly | No Poly check needed | Covered ✓ |
| Regression | Exact captured $0.49 scenario | Covered ✓ |
| Boundary | 3×34¢=$1.02 vs 2×34¢=68¢ | Covered ✓ |

## Test plan
- [x] All 102 existing tests pass
- [x] New unit tests for all arb types
- [x] Regression test for exact captured failure
- [ ] Manual test with live trading

🤖 Generated with [Claude Code](https://claude.ai/code)