### PR TITLE
fix(tui): remove dual log routing and fix execution log race

### DIFF
--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1048,7 +1048,6 @@ async fn main() -> Result<()> {
             trading_kalshi,
             trading_poly,
             dry_run,
-            Some(tui_log_tx.clone()),
         ));
         tokio::spawn(run_hybrid_execution_loop(exec_rx, hybrid_exec))
     } else {
@@ -1061,9 +1060,7 @@ async fn main() -> Result<()> {
             dry_run,
             clock.clone(),
         ));
-        let exec_tui_state = tui_state.clone();
-        let exec_log_tx = tui_log_tx.clone();
-        tokio::spawn(run_execution_loop(exec_rx, engine, Some(exec_tui_state), Some(exec_log_tx)))
+        tokio::spawn(run_execution_loop(exec_rx, engine))
     };
 
     // Confirmation handler task: receives arbs needing confirmation, manages queue and TUI

--- a/controller/tests/hybrid_executor_tests.rs
+++ b/controller/tests/hybrid_executor_tests.rs
@@ -99,7 +99,6 @@ async fn test_hybrid_executor_local_kalshi_drops_poly_arb() {
         None, // No Kalshi API client (but we're in dry_run mode)
         None, // No Poly client
         true, // dry_run
-        None, // No TUI log channel
     );
 
     // Try to execute a cross-platform arb (Poly YES + Kalshi NO)
@@ -139,7 +138,6 @@ async fn test_hybrid_executor_local_poly_drops_kalshi_arb() {
         None,
         None,
         true,
-        None,
     );
 
     // Try to execute a cross-platform arb
@@ -169,7 +167,6 @@ async fn test_hybrid_executor_no_local_no_remote_drops_all() {
         None,
         None,
         true,
-        None,
     );
 
     // All arb types should be dropped
@@ -215,7 +212,6 @@ async fn test_hybrid_executor_routes_to_remote_when_available() {
         None,
         None,
         true,
-        None,
     );
 
     let req = make_arb_request(ArbType::PolyYesKalshiNo);
@@ -274,7 +270,6 @@ async fn test_hybrid_executor_drops_arb_when_missing_remote_trader() {
         None,
         None,
         true,
-        None,
     );
 
     // Cross-platform arb should be dropped (no Poly trader)
@@ -317,7 +312,6 @@ async fn test_hybrid_executor_local_kalshi_remote_poly() {
         None, // No actual Kalshi client (dry_run will handle it)
         None,
         true, // dry_run
-        None, // No TUI log channel
     );
 
     let req = make_arb_request(ArbType::PolyYesKalshiNo);
@@ -362,7 +356,6 @@ async fn test_hybrid_executor_local_poly_remote_kalshi() {
         None,
         None,
         true,
-        None,
     );
 
     let req = make_arb_request(ArbType::PolyYesKalshiNo);
@@ -404,7 +397,6 @@ async fn test_hybrid_executor_poly_only_arb() {
         None,
         None,
         true,
-        None,
     );
 
     let req = make_arb_request(ArbType::PolyOnly);
@@ -449,7 +441,6 @@ async fn test_hybrid_executor_kalshi_only_arb() {
         None,
         None,
         true,
-        None,
     );
 
     let req = make_arb_request(ArbType::KalshiOnly);
@@ -499,7 +490,6 @@ async fn test_hybrid_executor_drops_zero_profit_arb() {
         None,
         None,
         true,
-        None,
     );
 
     // Prices sum to more than $1 (no profit)
@@ -544,7 +534,6 @@ async fn test_hybrid_executor_drops_insufficient_size_arb() {
         None,
         None,
         true,
-        None,
     );
 
     // Size too small for even 1 contract
@@ -594,7 +583,6 @@ async fn test_hybrid_executor_deduplication() {
         None,
         None,
         true,
-        None,
     ));
 
     let req = make_arb_request(ArbType::PolyYesKalshiNo);


### PR DESCRIPTION
## Summary
- Fixes execution logs lost after TUI confirmation by removing dual log routing and deferring `TUI_ACTIVE=false` until after log drain
- Removes redundant manual `log_tx`/`tui_state` routing from `run_execution_loop` and `HybridExecutor` — all logging now goes through tracing macros and `TuiAwareWriter` handles routing

## Root cause
- **Race**: TUI set `TUI_ACTIVE=false` before spawned execution tasks logged, so `TuiAwareWriter` routed to stdout instead of the TUI channel
- **Dual routing**: Manual `log_tx` channel routing in `run_execution_loop` and `HybridExecutor` duplicated what `TuiAwareWriter` already does via the tracing subscriber

## Changes
- `controller/src/execution.rs` — simplified `run_execution_loop` (2 params instead of 4), removed log closures
- `controller/src/remote_execution.rs` — removed `log_tx` from `HybridExecutor`, replaced `self.log_*()` with `info!()`/`warn!()`/`error!()`
- `controller/src/main.rs` — updated callers
- `controller/src/confirm_tui.rs` — defer `TUI_ACTIVE=false` until after draining log channel and dumping buffer
- `controller/tests/` — updated test signatures, fixed TUI log routing test

## Test plan
- [x] `test_execution_logs_arrive_on_log_tx_when_tui_active` — previously failing, now passes
- [x] All 12 hybrid executor tests pass
- [x] All execution engine integration tests pass
- [x] `cargo test` passes (pre-existing position tracker failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)