### PR TITLE
feat: unified session directory for remote debugging

### DIFF
--- a/controller/src/confirm_log.rs
+++ b/controller/src/confirm_log.rs
@@ -56,14 +56,18 @@ pub struct ConfirmationLogger {
 }
 
 impl ConfirmationLogger {
-    /// Create a new logger with a timestamped filename in .confirmations/
+    /// Create a new logger that writes `confirmations.json` into the session directory.
+    ///
+    /// Falls back to `.confirmations/confirmations_{timestamp}.json` if no session dir exists.
     pub fn new() -> Result<Self> {
-        let dir = PathBuf::from(".confirmations");
-        std::fs::create_dir_all(&dir)?;
-
-        let timestamp = Local::now().format("%Y-%m-%d_%H-%M-%S");
-        let filename = format!("confirmations_{}.json", timestamp);
-        let file_path = dir.join(&filename);
+        let file_path = if let Some(session) = crate::paths::session_dir() {
+            session.join("confirmations.json")
+        } else {
+            let dir = PathBuf::from(".confirmations");
+            std::fs::create_dir_all(&dir)?;
+            let timestamp = Local::now().format("%Y-%m-%d_%H-%M-%S");
+            dir.join(format!("confirmations_{}.json", timestamp))
+        };
 
         let file = OpenOptions::new()
             .create(true)


### PR DESCRIPTION
## Summary
- All per-run artifacts now live under `.sessions/{timestamp}/`: log file, HTTP captures, confirmation decisions, and a symlink to `positions.json`
- One `scp -r .sessions/<timestamp>/ local:~/debug/` grabs everything needed for debugging
- Old `.logs/` cleanup logic replaced by session-level cleanup (keeps last 10 sessions)

## Test plan
- [x] `cargo build --release` compiles
- [x] `cargo test` passes (2 pre-existing failures on branch unrelated to this change)
- [ ] Run with `DRY_RUN=1` → verify `.sessions/{timestamp}/` created with `controller.log` and `positions.json` symlink
- [ ] Run with `CAPTURE_DIR=1` → captures go into `{session}/captures/`
- [ ] Verify `SESSION_DIR` env var overrides base directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)